### PR TITLE
Standardize export Badge component

### DIFF
--- a/src/components/Badge/index.ts
+++ b/src/components/Badge/index.ts
@@ -1,0 +1,1 @@
+export { Badge } from "./Badge";

--- a/src/stories/Components.Badge.stories.tsx
+++ b/src/stories/Components.Badge.stories.tsx
@@ -2,9 +2,9 @@
 
 import "./../utils/reset.css";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Badge } from "../components/Badge/Badge";
 import { HabitatTheme } from "../utils/theme.css";
 import { ReactNode } from "react";
+import { Badge } from "../components/Badge";
 
 const BadgeIcon = () => {
   return (


### PR DESCRIPTION
## Figma reference

Not need, just technical stuff

## What

Standardize export Badge component

## Why

In order to import the Badge componente like this `import { Badge } from "../components/Badge";` instead `import { Badge } from "../components/Badge/Badge";`

## Release checklist

- [x] assign this PR to yourself
- [x] add meaningful labels
- [x] add at least 2 reviewers

(_Chromatic approvals, unit tests outcome and devs approval are already verified automatically_)
