### PR TITLE
add new html prop to typography components

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@casavo/habitat",
   "description": "Casavo Design System Library",
   "private": false,
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "type": "module",
   "license": "Apache 2.0",
   "homepage": "https://github.com/casavo/habitat",

--- a/src/components/Typography/Typography.css.ts
+++ b/src/components/Typography/Typography.css.ts
@@ -1,12 +1,17 @@
 import { recipe } from "@vanilla-extract/recipes";
 import { mq } from "../../utils/mediaqueries";
-import { fontFace, style } from "@vanilla-extract/css";
+import { fontFace, globalStyle, style } from "@vanilla-extract/css";
 
 const Bagoss = fontFace({
   src: 'url("https://cdn-base-ui.casavo.com/fonts/BagossCondensed-Light.woff2")',
 });
 
 const whiteSpace = "pre-line";
+
+globalStyle("a", {
+  // TODO: change this to a color token when --greyscale-600-black will be available
+  color: "#1D1D1B",
+});
 
 export const HeadingsStyle = recipe({
   base: {

--- a/src/components/Typography/Typography.css.ts
+++ b/src/components/Typography/Typography.css.ts
@@ -6,6 +6,8 @@ const Bagoss = fontFace({
   src: 'url("https://cdn-base-ui.casavo.com/fonts/BagossCondensed-Light.woff2")',
 });
 
+const Inter = "Inter, -apple-system, BlinkMacSystemFont, sans-serif";
+
 const whiteSpace = "pre-line";
 
 globalStyle("a", {
@@ -15,7 +17,6 @@ globalStyle("a", {
 
 export const HeadingsStyle = recipe({
   base: {
-    fontFamily: Bagoss,
     fontSize: 32,
     fontStyle: "normal",
     fontWeight: 300,
@@ -28,18 +29,21 @@ export const HeadingsStyle = recipe({
         "@media": {
           [mq.desktop]: { fontSize: 52 },
         },
+        fontFamily: Bagoss,
         fontSize: 40,
       },
       h2: {
         "@media": {
           [mq.desktop]: { fontSize: 32 },
         },
+        fontFamily: Bagoss,
         fontSize: 28,
       },
       h3: {
         "@media": {
           [mq.desktop]: { fontSize: 28 },
         },
+        fontFamily: Inter,
         fontSize: 24,
         fontWeight: 600,
       },
@@ -47,6 +51,7 @@ export const HeadingsStyle = recipe({
         "@media": {
           [mq.desktop]: { fontSize: 24 },
         },
+        fontFamily: Inter,
         fontSize: 20,
         fontWeight: 600,
       },
@@ -56,7 +61,7 @@ export const HeadingsStyle = recipe({
 
 // shared styles for non heading elements
 const base = style({
-  fontFamily: "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+  fontFamily: Inter,
   fontWeight: 400,
   lineHeight: 1.5,
   textDecoration: "none",

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -10,6 +10,7 @@ import {
 type BaseProps = {
   children?: React.ReactNode | string;
   color?: string;
+  html?: string;
 };
 
 type TextProps = BaseProps & {
@@ -21,43 +22,72 @@ type BodyProps = TextProps & {
   size?: "s" | "m" | "l";
 };
 
-export const H1 = ({ children }: BaseProps) => (
-  <h1 className={HeadingsStyle({ element: "h1" })}>{children}</h1>
+const conditionalHTML = (html?: string) => {
+  const attrs: { [key: string]: object } = {};
+  html ? (attrs.dangerouslySetInnerHTML = { __html: html }) : null;
+  return attrs;
+};
+
+export const H1 = ({ children, html }: BaseProps) => (
+  <h1 className={HeadingsStyle({ element: "h1" })} {...conditionalHTML(html)}>
+    {!html ? children : null}
+  </h1>
 );
 
-export const H2 = ({ children }: BaseProps) => (
-  <h2 className={HeadingsStyle({ element: "h2" })}>{children}</h2>
+export const H2 = ({ children, html }: BaseProps) => (
+  <h2 className={HeadingsStyle({ element: "h2" })} {...conditionalHTML(html)}>
+    {!html ? children : null}
+  </h2>
 );
 
-export const H3 = ({ children }: BaseProps) => (
-  <h3 className={HeadingsStyle({ element: "h3" })}>{children}</h3>
+export const H3 = ({ children, html }: BaseProps) => (
+  <h3 className={HeadingsStyle({ element: "h3" })} {...conditionalHTML(html)}>
+    {!html ? children : null}
+  </h3>
 );
 
-export const H4 = ({ children }: BaseProps) => (
-  <h4 className={HeadingsStyle({ element: "h4" })}>{children}</h4>
+export const H4 = ({ children, html }: BaseProps) => (
+  <h4 className={HeadingsStyle({ element: "h4" })} {...conditionalHTML(html)}>
+    {!html ? children : null}
+  </h4>
 );
 
 export const Body = ({
   children,
+  html,
   size = "m",
   strong = false,
   underline = false,
 }: BodyProps) => (
-  <p className={BodyStyle({ size, strong, underline })}>{children}</p>
+  <p
+    className={BodyStyle({ size, strong, underline })}
+    {...conditionalHTML(html)}
+  >
+    {!html ? children : null}
+  </p>
 );
 
 export const Description = ({
   children,
+  html,
   strong = false,
   underline = false,
 }: TextProps) => (
-  <p className={DescriptionStyle({ strong, underline })}>{children}</p>
+  <p
+    className={DescriptionStyle({ strong, underline })}
+    {...conditionalHTML(html)}
+  >
+    {!html ? children : null}
+  </p>
 );
 
 export const Caption = ({
   children,
+  html,
   strong = false,
   underline = false,
 }: TextProps) => (
-  <p className={CaptionStyle({ strong, underline })}>{children}</p>
+  <p className={CaptionStyle({ strong, underline })} {...conditionalHTML(html)}>
+    {!html ? children : null}
+  </p>
 );

--- a/src/stories/Typography.Body.H1.stories.tsx
+++ b/src/stories/Typography.Body.H1.stories.tsx
@@ -6,7 +6,15 @@ import "./../utils/reset.css";
 import { H1 } from "./../components/Typography";
 
 const meta: Meta<typeof H1> = {
-  argTypes: {},
+  argTypes: {
+    html: {
+      control: "text",
+      description: "allow to pass HTML directly to the component",
+    },
+  },
+  args: {
+    html: `<a href="https://www.casavo.com">link to Casavo website</a>`,
+  },
   component: H1,
   title: "Typography/H1",
 };
@@ -21,8 +29,8 @@ type Story = StoryObj<typeof H1>;
  */
 
 export const _H1: Story = {
-  render: () => (
-    <H1>
+  render: ({ ...args }) => (
+    <H1 html={args.html}>
       Idque Caesaris facere voluntate liceret: sese habere. dque Caesaris facere
     </H1>
   ),

--- a/src/stories/Typography.Body.H2.stories.tsx
+++ b/src/stories/Typography.Body.H2.stories.tsx
@@ -6,7 +6,15 @@ import "./../utils/reset.css";
 import { H2 } from "./../components/Typography";
 
 const meta: Meta<typeof H2> = {
-  argTypes: {},
+  argTypes: {
+    html: {
+      control: "text",
+      description: "allow to pass HTML directly to the component",
+    },
+  },
+  args: {
+    html: undefined,
+  },
   component: H2,
   title: "Typography/H2",
 };
@@ -21,8 +29,8 @@ type Story = StoryObj<typeof H2>;
  */
 
 export const _H2: Story = {
-  render: () => (
-    <H2>
+  render: ({ ...args }) => (
+    <H2 html={args.html}>
       Idque Caesaris facere voluntate liceret: sese habere. dque Caesaris facere
     </H2>
   ),

--- a/src/stories/Typography.Body.H3.stories.tsx
+++ b/src/stories/Typography.Body.H3.stories.tsx
@@ -6,7 +6,15 @@ import "./../utils/reset.css";
 import { H3 } from "./../components/Typography";
 
 const meta: Meta<typeof H3> = {
-  argTypes: {},
+  argTypes: {
+    html: {
+      control: "text",
+      description: "allow to pass HTML directly to the component",
+    },
+  },
+  args: {
+    html: undefined,
+  },
   component: H3,
   title: "Typography/H3",
 };
@@ -21,8 +29,8 @@ type Story = StoryObj<typeof H3>;
  */
 
 export const _H3: Story = {
-  render: () => (
-    <H3>
+  render: ({ ...args }) => (
+    <H3 html={args.html}>
       Idque Caesaris facere voluntate liceret: sese habere. dque Caesaris facere
     </H3>
   ),

--- a/src/stories/Typography.Body.H4.stories.tsx
+++ b/src/stories/Typography.Body.H4.stories.tsx
@@ -6,7 +6,15 @@ import "./../utils/reset.css";
 import { H4 } from "./../components/Typography";
 
 const meta: Meta<typeof H4> = {
-  argTypes: {},
+  argTypes: {
+    html: {
+      control: "text",
+      description: "allow to pass HTML directly to the component",
+    },
+  },
+  args: {
+    html: undefined,
+  },
   component: H4,
   title: "Typography/H4",
 };
@@ -21,8 +29,8 @@ type Story = StoryObj<typeof H4>;
  */
 
 export const _H4: Story = {
-  render: () => (
-    <H4>
+  render: ({ ...args }) => (
+    <H4 html={args.html}>
       Idque Caesaris facere voluntate liceret: sese habere. dque Caesaris facere
     </H4>
   ),

--- a/src/stories/Typography.Body.stories.tsx
+++ b/src/stories/Typography.Body.stories.tsx
@@ -5,6 +5,15 @@ import { Body } from "./../components/Typography";
 
 const meta: Meta<typeof Body> = {
   argTypes: {
+    html: {
+      control: "text",
+      description: "allow to pass HTML directly to the component",
+    },
+    size: {
+      control: { options: ["s", "m", "l"], type: "radio" },
+      defaultValue: "m",
+      description: "define the font size",
+    },
     strong: {
       control: { type: "boolean" },
       defaultValue: false,
@@ -15,15 +24,11 @@ const meta: Meta<typeof Body> = {
       defaultValue: false,
       description: "toggle the underline text decoration",
     },
-    size: {
-      control: { type: "radio", options: ["s", "m", "l"] },
-      defaultValue: "m",
-      description: "define the font size",
-    },
   },
   args: {
-    strong: false,
+    html: undefined,
     size: "m",
+    strong: false,
     underline: false,
   },
   component: Body,
@@ -41,7 +46,12 @@ type Story = StoryObj<typeof Body>;
 
 export const _Body: Story = {
   render: ({ ...args }) => (
-    <Body size={args.size} strong={args.strong} underline={args.underline}>
+    <Body
+      html={args.html}
+      size={args.size}
+      strong={args.strong}
+      underline={args.underline}
+    >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse diam
       lorem, tempor sed orci non, ornare laoreet dui. Proin nec tincidunt enim.
       Phasellus et diam tincidunt est semper mattis. Ut sed nulla non leo

--- a/src/stories/Typography.Caption.stories.tsx
+++ b/src/stories/Typography.Caption.stories.tsx
@@ -5,18 +5,23 @@ import { Caption } from "./../components/Typography";
 
 const meta: Meta<typeof Caption> = {
   argTypes: {
+    html: {
+      control: "text",
+      description: "allow to pass HTML directly to the component",
+    },
     strong: {
+      caption: "toggle the strong/bold font type",
       control: { type: "boolean" },
       defaultValue: false,
-      caption: "toggle the strong/bold font type",
     },
     underline: {
+      caption: "toggle the underline text decoration",
       control: { type: "boolean" },
       defaultValue: false,
-      caption: "toggle the underline text decoration",
     },
   },
   args: {
+    html: undefined,
     strong: false,
     underline: false,
   },
@@ -35,7 +40,7 @@ type Story = StoryObj<typeof Caption>;
 
 export const _Caption: Story = {
   render: ({ ...args }) => (
-    <Caption strong={args.strong} underline={args.underline}>
+    <Caption html={args.html} strong={args.strong} underline={args.underline}>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse diam
       lorem, tempor sed orci non, ornare laoreet dui. Proin nec tincidunt enim.
       Phasellus et diam tincidunt est semper mattis. Ut sed nulla non leo

--- a/src/stories/Typography.Description.stories.tsx
+++ b/src/stories/Typography.Description.stories.tsx
@@ -5,6 +5,10 @@ import { Description } from "./../components/Typography";
 
 const meta: Meta<typeof Description> = {
   argTypes: {
+    html: {
+      control: "text",
+      description: "allow to pass HTML directly to the component",
+    },
     strong: {
       control: { type: "boolean" },
       defaultValue: false,
@@ -17,6 +21,7 @@ const meta: Meta<typeof Description> = {
     },
   },
   args: {
+    html: undefined,
     strong: false,
     underline: false,
   },
@@ -35,7 +40,11 @@ type Story = StoryObj<typeof Description>;
 
 export const _Description: Story = {
   render: ({ ...args }) => (
-    <Description strong={args.strong} underline={args.underline}>
+    <Description
+      html={args.html}
+      strong={args.strong}
+      underline={args.underline}
+    >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse diam
       lorem, tempor sed orci non, ornare laoreet dui. Proin nec tincidunt enim.
       Phasellus et diam tincidunt est semper mattis. Ut sed nulla non leo


### PR DESCRIPTION
## Figma reference
nope, it was reported by @alefiori during the implementation on the components on a project as it breaks some use cases of the i18n solution, closes #35 

## What
I've added an `html` prop to every typography component that if it has values will set the `dangerouslySetInnerHTML` of the wrapped tag, since in React you can't have both `innerHTML` and `children` on the same component, the first will always override the second.

Please use this feature only for this specific case (when you want as children a function that returnts an HTML string) and keep the `children` for everything else

## Notes
- also added a global style for the links `<a />` to match the default text color
- fixing `H3` and `H4` using `Bagoss` font (they are defined with `Inter` in figma)

