### PR TITLE
adding colors management in typography components

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           npm ci
 
+      - name: Check the codestyle
+        run: |
+          npm run lint
+
       - name: Build the static Storybook site
         run: |
           npm run build:storybook

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,10 @@ jobs:
         run: |
           npm ci
 
+      - name: Check the codestyle
+        run: |
+          npm run lint
+
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,10 @@
         "@storybook/react": "7.5.3",
         "@storybook/react-vite": "7.5.3",
         "@storybook/testing-library": "0.2.2",
-        "@types/react": "18.2.37",
-        "@types/react-dom": "18.2.15",
-        "@typescript-eslint/eslint-plugin": "6.11.0",
-        "@typescript-eslint/parser": "6.11.0",
+        "@types/react": "18.2.38",
+        "@types/react-dom": "18.2.17",
+        "@typescript-eslint/eslint-plugin": "6.12.0",
+        "@typescript-eslint/parser": "6.12.0",
         "@vanilla-extract/vite-plugin": "3.9.2",
         "@vitejs/plugin-react": "4.2.0",
         "chromatic": "9.1.0",
@@ -43,7 +43,7 @@
         "react-aria-components": "1.0.0-beta.1",
         "storybook": "7.5.3",
         "style-dictionary": "3.9.0",
-        "typescript": "5.2.2",
+        "typescript": "5.3.2",
         "vite": "4.5.0",
         "vite-plugin-dts": "3.6.3"
       },
@@ -7290,9 +7290,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.37",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.37.tgz",
-      "integrity": "sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==",
+      "version": "18.2.38",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.38.tgz",
+      "integrity": "sha512-cBBXHzuPtQK6wNthuVMV6IjHAFkdl/FOPFIlkd81/Cd1+IqkHu/A+w4g43kaQQoYHik/ruaQBDL72HyCy1vuMw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -7301,9 +7301,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.15",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.15.tgz",
-      "integrity": "sha512-HWMdW+7r7MR5+PZqJF6YFNSCtjz1T0dsvo/f1BV6HkV+6erD/nA7wd9NM00KVG83zf2nJ7uATPO9ttdIPvi3gg==",
+      "version": "18.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
+      "integrity": "sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -7370,16 +7370,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.11.0.tgz",
-      "integrity": "sha512-uXnpZDc4VRjY4iuypDBKzW1rz9T5YBBK0snMn8MaTSNd2kMlj50LnLBABELjJiOL5YHk7ZD8hbSpI9ubzqYI0w==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.12.0.tgz",
+      "integrity": "sha512-XOpZ3IyJUIV1b15M7HVOpgQxPPF7lGXgsfcEIu3yDxFPaf/xZKt7s9QO/pbk7vpWQyVulpJbu4E5LwpZiQo4kA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.11.0",
-        "@typescript-eslint/type-utils": "6.11.0",
-        "@typescript-eslint/utils": "6.11.0",
-        "@typescript-eslint/visitor-keys": "6.11.0",
+        "@typescript-eslint/scope-manager": "6.12.0",
+        "@typescript-eslint/type-utils": "6.12.0",
+        "@typescript-eslint/utils": "6.12.0",
+        "@typescript-eslint/visitor-keys": "6.12.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -7612,15 +7612,15 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.11.0.tgz",
-      "integrity": "sha512-+whEdjk+d5do5nxfxx73oanLL9ghKO3EwM9kBCkUtWMRwWuPaFv9ScuqlYfQ6pAD6ZiJhky7TZ2ZYhrMsfMxVQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.12.0.tgz",
+      "integrity": "sha512-s8/jNFPKPNRmXEnNXfuo1gemBdVmpQsK1pcu+QIvuNJuhFzGrpD7WjOcvDc/+uEdfzSYpNu7U/+MmbScjoQ6vg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.11.0",
-        "@typescript-eslint/types": "6.11.0",
-        "@typescript-eslint/typescript-estree": "6.11.0",
-        "@typescript-eslint/visitor-keys": "6.11.0",
+        "@typescript-eslint/scope-manager": "6.12.0",
+        "@typescript-eslint/types": "6.12.0",
+        "@typescript-eslint/typescript-estree": "6.12.0",
+        "@typescript-eslint/visitor-keys": "6.12.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -7640,13 +7640,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.11.0.tgz",
-      "integrity": "sha512-0A8KoVvIURG4uhxAdjSaxy8RdRE//HztaZdG8KiHLP8WOXSk0vlF7Pvogv+vlJA5Rnjj/wDcFENvDaHb+gKd1A==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.12.0.tgz",
+      "integrity": "sha512-5gUvjg+XdSj8pcetdL9eXJzQNTl3RD7LgUiYTl8Aabdi8hFkaGSYnaS6BLc0BGNaDH+tVzVwmKtWvu0jLgWVbw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.11.0",
-        "@typescript-eslint/visitor-keys": "6.11.0"
+        "@typescript-eslint/types": "6.12.0",
+        "@typescript-eslint/visitor-keys": "6.12.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -7657,13 +7657,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.11.0.tgz",
-      "integrity": "sha512-nA4IOXwZtqBjIoYrJcYxLRO+F9ri+leVGoJcMW1uqr4r1Hq7vW5cyWrA43lFbpRvQ9XgNrnfLpIkO3i1emDBIA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.12.0.tgz",
+      "integrity": "sha512-WWmRXxhm1X8Wlquj+MhsAG4dU/Blvf1xDgGaYCzfvStP2NwPQh6KBvCDbiOEvaE0filhranjIlK/2fSTVwtBng==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.11.0",
-        "@typescript-eslint/utils": "6.11.0",
+        "@typescript-eslint/typescript-estree": "6.12.0",
+        "@typescript-eslint/utils": "6.12.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -7684,9 +7684,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.11.0.tgz",
-      "integrity": "sha512-ZbEzuD4DwEJxwPqhv3QULlRj8KYTAnNsXxmfuUXFCxZmO6CF2gM/y+ugBSAQhrqaJL3M+oe4owdWunaHM6beqA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.12.0.tgz",
+      "integrity": "sha512-MA16p/+WxM5JG/F3RTpRIcuOghWO30//VEOvzubM8zuOOBYXsP+IfjoCXXiIfy2Ta8FRh9+IO9QLlaFQUU+10Q==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -7697,13 +7697,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.11.0.tgz",
-      "integrity": "sha512-Aezzv1o2tWJwvZhedzvD5Yv7+Lpu1by/U1LZ5gLc4tCx8jUmuSCMioPFRjliN/6SJIvY6HpTtJIWubKuYYYesQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.12.0.tgz",
+      "integrity": "sha512-vw9E2P9+3UUWzhgjyyVczLWxZ3GuQNT7QpnIY3o5OMeLO/c8oHljGc8ZpryBMIyympiAAaKgw9e5Hl9dCWFOYw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.11.0",
-        "@typescript-eslint/visitor-keys": "6.11.0",
+        "@typescript-eslint/types": "6.12.0",
+        "@typescript-eslint/visitor-keys": "6.12.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -7757,17 +7757,17 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.11.0.tgz",
-      "integrity": "sha512-p23ibf68fxoZy605dc0dQAEoUsoiNoP3MD9WQGiHLDuTSOuqoTsa4oAy+h3KDkTcxbbfOtUjb9h3Ta0gT4ug2g==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.12.0.tgz",
+      "integrity": "sha512-LywPm8h3tGEbgfyjYnu3dauZ0U7R60m+miXgKcZS8c7QALO9uWJdvNoP+duKTk2XMWc7/Q3d/QiCuLN9X6SWyQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.11.0",
-        "@typescript-eslint/types": "6.11.0",
-        "@typescript-eslint/typescript-estree": "6.11.0",
+        "@typescript-eslint/scope-manager": "6.12.0",
+        "@typescript-eslint/types": "6.12.0",
+        "@typescript-eslint/typescript-estree": "6.12.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -7815,12 +7815,12 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.11.0.tgz",
-      "integrity": "sha512-+SUN/W7WjBr05uRxPggJPSzyB8zUpaYo2hByKasWbqr3PM8AXfZt8UHdNpBS1v9SA62qnSSMF3380SwDqqprgQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.12.0.tgz",
+      "integrity": "sha512-rg3BizTZHF1k3ipn8gfrzDXXSFKyOEB5zxYXInQ6z0hUvmQlhaZQzK+YmHmNViMA9HzW5Q9+bPPt90bU6GQwyw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.11.0",
+        "@typescript-eslint/types": "6.12.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -16629,9 +16629,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     "@storybook/react": "7.5.3",
     "@storybook/react-vite": "7.5.3",
     "@storybook/testing-library": "0.2.2",
-    "@types/react": "18.2.37",
-    "@types/react-dom": "18.2.15",
-    "@typescript-eslint/eslint-plugin": "6.11.0",
-    "@typescript-eslint/parser": "6.11.0",
+    "@types/react": "18.2.38",
+    "@types/react-dom": "18.2.17",
+    "@typescript-eslint/eslint-plugin": "6.12.0",
+    "@typescript-eslint/parser": "6.12.0",
     "@vanilla-extract/vite-plugin": "3.9.2",
     "@vitejs/plugin-react": "4.2.0",
     "chromatic": "9.1.0",
@@ -70,7 +70,7 @@
     "react-aria-components": "1.0.0-beta.1",
     "storybook": "7.5.3",
     "style-dictionary": "3.9.0",
-    "typescript": "5.2.2",
+    "typescript": "5.3.2",
     "vite": "4.5.0",
     "vite-plugin-dts": "3.6.3"
   }

--- a/src/components/Switch/Switch.css.ts
+++ b/src/components/Switch/Switch.css.ts
@@ -1,47 +1,48 @@
 import { recipe } from "@vanilla-extract/recipes";
 import { vars } from "../../utils/theme.css";
-import { style } from '@vanilla-extract/css'
+import { style } from "@vanilla-extract/css";
 
 export const base = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '0.572rem',
-  fontSize: '1.143rem',
-  ':hover': {
-    cursor: 'pointer'
+  ":hover": {
+    cursor: "pointer",
   },
+  alignItems: "center",
+  display: "flex",
+  fontSize: "1.143rem",
+  gap: "0.572rem",
   selectors: {
-    '&[data-disabled]:hover': {
-      cursor: 'default'
-    }
-  }
-})
+    "&[data-disabled]:hover": {
+      cursor: "default",
+    },
+  },
+});
 
 const indicatorBase = style({
-  width: '40px',
-  height: '22px',
-  border: 'none',
-  background: vars.colors.neutral[40], // atm missing in vars
-  borderRadius: '11px',
-  transition: 'all 300ms',
-  '::before': {
-    content: '',
-    display: 'block',
-    margin: '0.143rem',
-    width: '18px',
-    height: '18px',
+  "::before": {
     background: vars.colors.neutral[0],
-    borderRadius: '16px',
-    transition: 'all 200ms',
+    borderRadius: "16px",
+    content: "",
+    display: "block",
+    height: "18px",
+    margin: "0.143rem",
+    transition: "all 200ms",
+    width: "18px",
   },
+  background: vars.colors.neutral[40],
+  border: "none",
+  // atm missing in vars
+  borderRadius: "11px",
+
+  height: "22px",
+
   selectors: {
-    [`${base}[data-selected] &`]:{
+    [`${base}[data-selected] &`]: {
+      background: vars.colors.neutral[100],
       borderColor: vars.colors.neutral[100],
-      background:  vars.colors.neutral[100],
     },
     [`${base}[data-selected] &:before`]: {
       background: vars.colors.neutral[0],
-      transform: 'translateX(100%)'
+      transform: "translateX(100%)",
     },
     [`${base}[data-disabled] &`]: {
       background: vars.colors.neutral[10],
@@ -51,30 +52,31 @@ const indicatorBase = style({
       background: vars.colors.neutral[60],
       borderColor: vars.colors.neutral[60],
     },
-    
-  }
-})
+  },
+  transition: "all 300ms",
+  width: "40px",
+});
 
 export const indicator = recipe({
   base: indicatorBase,
   variants: {
     size: {
       normal: {
-        width: '40px',
-        height: '22px',
-        '::before': {
-          width: '18px',
-          height: '18px'
-        }
+        "::before": {
+          height: "18px",
+          width: "18px",
+        },
+        height: "22px",
+        width: "40px",
       },
       small: {
-        width: '28px',
-        height: '16px',
-        '::before': {
-          width: '12px',
-          height: '12px'
-        }
-      }
-    }
-  }
-})
+        "::before": {
+          height: "12px",
+          width: "12px",
+        },
+        height: "16px",
+        width: "28px",
+      },
+    },
+  },
+});

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,30 +1,31 @@
-import React from "react"
-import {Switch as SwitchAria} from 'react-aria-components';
+import React from "react";
+import { Switch as SwitchAria } from "react-aria-components";
 import { base, indicator } from "./Switch.css";
 
-
 type Props = {
-  size?: 'normal' | 'small'
-  disabled?: boolean
-  onChange?: VoidFunction
-  isSelected?: boolean
-}
+  disabled?: boolean;
+  isSelected?: boolean;
+  onChange?: VoidFunction;
+  size?: "normal" | "small";
+};
 
-
-
-export const Switch:React.FC<Props> =
-  ({size = 'normal', onChange, isSelected, disabled}) => {
+export const Switch: React.FC<Props> = ({
+  size = "normal",
+  onChange,
+  isSelected,
+  disabled,
+}) => {
   const optionalProps = {
-    ...(onChange ? {onChange: onChange}: {}),
-    ...(typeof isSelected !== 'undefined' ? {isSelected: isSelected}: {})
-  }
+    ...(onChange ? { onChange: onChange } : {}),
+    ...(typeof isSelected !== "undefined" ? { isSelected: isSelected } : {}),
+  };
   return (
     <SwitchAria
       className={base}
       isDisabled={disabled || false}
       {...optionalProps}
     >
-      <div className={indicator({size})} />
+      <div className={indicator({ size })} />
     </SwitchAria>
-  )
-}
+  );
+};

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { vars } from "../../utils/theme.css";
+
 import {
   BodyStyle,
   CaptionStyle,
@@ -22,38 +24,67 @@ type BodyProps = TextProps & {
   size?: "s" | "m" | "l";
 };
 
-const conditionalHTML = (html?: string) => {
+/**
+ * It returns an object with the attributes to be passed to the component
+ */
+const conditionalAttrs = (html?: string, color?: string) => {
   const attrs: { [key: string]: object } = {};
   html ? (attrs.dangerouslySetInnerHTML = { __html: html }) : null;
+  color ? (attrs.style = { color: getColor(color) }) : null;
   return attrs;
 };
 
-export const H1 = ({ children, html }: BaseProps) => (
-  <h1 className={HeadingsStyle({ element: "h1" })} {...conditionalHTML(html)}>
+/**
+ * Starting from a string like "neutral.0" which is the path within the Vanilla Extract color
+ * variables, it returns the corresponding color as CSS variable value
+ */
+const getColor = (color?: string) => {
+  const fallback = vars.colors.neutral["0"];
+  const paths = color?.split(".");
+  const result =
+    paths && paths.reduce((acc, path) => acc[path as never], vars.colors);
+  return result || fallback;
+};
+
+export const H1 = ({ children, color, html }: BaseProps) => (
+  <h1
+    className={HeadingsStyle({ element: "h1" })}
+    {...conditionalAttrs(html, color)}
+  >
     {!html ? children : null}
   </h1>
 );
 
-export const H2 = ({ children, html }: BaseProps) => (
-  <h2 className={HeadingsStyle({ element: "h2" })} {...conditionalHTML(html)}>
+export const H2 = ({ children, color, html }: BaseProps) => (
+  <h2
+    className={HeadingsStyle({ element: "h2" })}
+    {...conditionalAttrs(html, color)}
+  >
     {!html ? children : null}
   </h2>
 );
 
-export const H3 = ({ children, html }: BaseProps) => (
-  <h3 className={HeadingsStyle({ element: "h3" })} {...conditionalHTML(html)}>
+export const H3 = ({ children, color, html }: BaseProps) => (
+  <h3
+    className={HeadingsStyle({ element: "h3" })}
+    {...conditionalAttrs(html, color)}
+  >
     {!html ? children : null}
   </h3>
 );
 
-export const H4 = ({ children, html }: BaseProps) => (
-  <h4 className={HeadingsStyle({ element: "h4" })} {...conditionalHTML(html)}>
+export const H4 = ({ children, color, html }: BaseProps) => (
+  <h4
+    className={HeadingsStyle({ element: "h4" })}
+    {...conditionalAttrs(html, color)}
+  >
     {!html ? children : null}
   </h4>
 );
 
 export const Body = ({
   children,
+  color,
   html,
   size = "m",
   strong = false,
@@ -61,7 +92,7 @@ export const Body = ({
 }: BodyProps) => (
   <p
     className={BodyStyle({ size, strong, underline })}
-    {...conditionalHTML(html)}
+    {...conditionalAttrs(html, color)}
   >
     {!html ? children : null}
   </p>
@@ -69,13 +100,14 @@ export const Body = ({
 
 export const Description = ({
   children,
+  color,
   html,
   strong = false,
   underline = false,
 }: TextProps) => (
   <p
     className={DescriptionStyle({ strong, underline })}
-    {...conditionalHTML(html)}
+    {...conditionalAttrs(html, color)}
   >
     {!html ? children : null}
   </p>
@@ -83,11 +115,15 @@ export const Description = ({
 
 export const Caption = ({
   children,
+  color,
   html,
   strong = false,
   underline = false,
 }: TextProps) => (
-  <p className={CaptionStyle({ strong, underline })} {...conditionalHTML(html)}>
+  <p
+    className={CaptionStyle({ strong, underline })}
+    {...conditionalAttrs(html, color)}
+  >
     {!html ? children : null}
   </p>
 );

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -9,9 +9,19 @@ import {
   HeadingsStyle,
 } from "./Typography.css";
 
+import tokens from "./../../utils/tokens.json";
+
+type NestedKeyOf<ObjectType extends object> = {
+  [Key in keyof ObjectType & string]: ObjectType[Key] extends object
+    ? `${Key}.${NestedKeyOf<ObjectType[Key]>}`
+    : `${Key}`;
+}[keyof ObjectType & string];
+
+type Colors = NestedKeyOf<typeof tokens.foundations.colors>;
+
 type BaseProps = {
   children?: React.ReactNode | string;
-  color?: string;
+  color?: Colors;
   html?: string;
 };
 

--- a/src/stories/Typography.Body.stories.tsx
+++ b/src/stories/Typography.Body.stories.tsx
@@ -3,29 +3,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 import "./../utils/reset.css";
 import { Body } from "./../components/Typography";
 import { StoryLayout } from "./components/StoryLayout";
+import { bodyArgTypes as argTypes } from "./utils/typography";
 
 const meta: Meta<typeof Body> = {
-  argTypes: {
-    html: {
-      control: "text",
-      description: "allow to pass HTML directly to the component",
-    },
-    size: {
-      control: { options: ["s", "m", "l"], type: "radio" },
-      defaultValue: "m",
-      description: "define the font size",
-    },
-    strong: {
-      control: { type: "boolean" },
-      defaultValue: false,
-      description: "toggle the strong/bold font type",
-    },
-    underline: {
-      control: { type: "boolean" },
-      defaultValue: false,
-      description: "toggle the underline text decoration",
-    },
-  },
+  argTypes,
   args: {
     html: undefined,
     size: "m",
@@ -53,6 +34,7 @@ export const _Body: Story = {
       usage={"<Body>Some text here</Body>"}
     >
       <Body
+        color={args.color}
         html={args.html}
         size={args.size}
         strong={args.strong}

--- a/src/stories/Typography.Caption.stories.tsx
+++ b/src/stories/Typography.Caption.stories.tsx
@@ -2,24 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Caption } from "./../components/Typography";
 import { StoryLayout } from "./components/StoryLayout";
+import { bodyArgTypes as argTypes } from "./utils/typography";
 
 const meta: Meta<typeof Caption> = {
-  argTypes: {
-    html: {
-      control: "text",
-      description: "allow to pass HTML directly to the component",
-    },
-    strong: {
-      caption: "toggle the strong/bold font type",
-      control: { type: "boolean" },
-      defaultValue: false,
-    },
-    underline: {
-      caption: "toggle the underline text decoration",
-      control: { type: "boolean" },
-      defaultValue: false,
-    },
-  },
+  argTypes,
   args: {
     html: undefined,
     strong: false,
@@ -48,7 +34,12 @@ export const _Caption: Story = {
       title="Typography/Caption"
       usage={"<Caption>Some text here</Caption>"}
     >
-      <Caption html={args.html} strong={args.strong} underline={args.underline}>
+      <Caption
+        color={args.color}
+        html={args.html}
+        strong={args.strong}
+        underline={args.underline}
+      >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
         diam lorem, tempor sed orci non, ornare laoreet dui. Proin nec tincidunt
         enim. Phasellus et diam tincidunt est semper mattis. Ut sed nulla non

--- a/src/stories/Typography.Description.stories.tsx
+++ b/src/stories/Typography.Description.stories.tsx
@@ -2,24 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Description } from "./../components/Typography";
 import { StoryLayout } from "./components/StoryLayout";
+import { bodyArgTypes as argTypes } from "./utils/typography";
 
 const meta: Meta<typeof Description> = {
-  argTypes: {
-    html: {
-      control: "text",
-      description: "allow to pass HTML directly to the component",
-    },
-    strong: {
-      control: { type: "boolean" },
-      defaultValue: false,
-      description: "toggle the strong/bold font type",
-    },
-    underline: {
-      control: { type: "boolean" },
-      defaultValue: false,
-      description: "toggle the underline text decoration",
-    },
-  },
+  argTypes,
   args: {
     html: undefined,
     strong: false,
@@ -44,6 +30,7 @@ export const _Description: Story = {
       usage={"<Description>Some text here</Description>"}
     >
       <Description
+        color={args.color}
         html={args.html}
         strong={args.strong}
         underline={args.underline}

--- a/src/stories/Typography.H1.stories.tsx
+++ b/src/stories/Typography.H1.stories.tsx
@@ -4,14 +4,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { H1 } from "../components/Typography";
 import { StoryLayout } from "./components/StoryLayout";
+import { argTypes } from "./utils/typography";
 
 const meta: Meta<typeof H1> = {
-  argTypes: {
-    html: {
-      control: "text",
-      description: "allow to pass HTML directly to the component",
-    },
-  },
+  argTypes,
   args: {
     html: `<a href="https://www.casavo.com">link to Casavo website</a>`,
   },
@@ -31,7 +27,7 @@ export const _H1: Story = {
       title="Typography/H1"
       usage={"<H1>Some text here</H1>"}
     >
-      <H1 html={args.html}>
+      <H1 color={args.color} html={args.html}>
         Idque Caesaris facere voluntate liceret: sese habere. dque Caesaris
         facere
       </H1>

--- a/src/stories/Typography.H2.stories.tsx
+++ b/src/stories/Typography.H2.stories.tsx
@@ -4,14 +4,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { H2 } from "../components/Typography";
 import { StoryLayout } from "./components/StoryLayout";
+import { argTypes } from "./utils/typography";
 
 const meta: Meta<typeof H2> = {
-  argTypes: {
-    html: {
-      control: "text",
-      description: "allow to pass HTML directly to the component",
-    },
-  },
+  argTypes,
   args: {
     html: undefined,
   },
@@ -31,7 +27,7 @@ export const _H2: Story = {
       title="Typography/H2"
       usage={"<H2>Some text here</H2>"}
     >
-      <H2 html={args.html}>
+      <H2 color={args.color} html={args.html}>
         Idque Caesaris facere voluntate liceret: sese habere. dque Caesaris
         facere
       </H2>

--- a/src/stories/Typography.H3.stories.tsx
+++ b/src/stories/Typography.H3.stories.tsx
@@ -4,14 +4,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { H3 } from "../components/Typography";
 import { StoryLayout } from "./components/StoryLayout";
+import { argTypes } from "./utils/typography";
 
 const meta: Meta<typeof H3> = {
-  argTypes: {
-    html: {
-      control: "text",
-      description: "allow to pass HTML directly to the component",
-    },
-  },
+  argTypes,
   args: {
     html: undefined,
   },
@@ -31,7 +27,7 @@ export const _H3: Story = {
       title="Typography/H3"
       usage={"<H3>Some text here</H3>"}
     >
-      <H3 html={args.html}>
+      <H3 color={args.color} html={args.html}>
         Idque Caesaris facere voluntate liceret: sese habere. dque Caesaris
         facere
       </H3>

--- a/src/stories/Typography.H4.stories.tsx
+++ b/src/stories/Typography.H4.stories.tsx
@@ -4,14 +4,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { H4 } from "../components/Typography";
 import { StoryLayout } from "./components/StoryLayout";
+import { argTypes } from "./utils/typography";
 
 const meta: Meta<typeof H4> = {
-  argTypes: {
-    html: {
-      control: "text",
-      description: "allow to pass HTML directly to the component",
-    },
-  },
+  argTypes,
   args: {
     html: undefined,
   },
@@ -31,7 +27,7 @@ export const _H4: Story = {
       title="Typography/H4"
       usage={"<H4>Some text here</H4>"}
     >
-      <H4 html={args.html}>
+      <H4 color={args.color} html={args.html}>
         Idque Caesaris facere voluntate liceret: sese habere. dque Caesaris
         facere
       </H4>

--- a/src/stories/utils/colors.ts
+++ b/src/stories/utils/colors.ts
@@ -1,0 +1,16 @@
+import { vars } from "../../utils/theme.css";
+
+const findKeys = (obj: never, prefix: string = ""): string[] => {
+  const keys = Object.keys(obj).map((key) => {
+    const nestedKey = prefix === "" ? key : `${prefix}.${key}`;
+
+    return typeof obj[key] !== "object"
+      ? nestedKey
+      : findKeys(obj[key], nestedKey);
+  });
+  return keys.flat();
+};
+
+export const getColors = (): string[] => {
+  return findKeys(vars.colors as never);
+};

--- a/src/stories/utils/typography.ts
+++ b/src/stories/utils/typography.ts
@@ -1,0 +1,32 @@
+import { getColors } from "./colors";
+
+export const argTypes = {
+  color: {
+    control: "select",
+    description: "set a color token from the available ones",
+    options: ["", ...getColors()],
+  },
+  html: {
+    control: "text",
+    description: "allow to pass HTML directly to the component",
+  },
+};
+
+export const bodyArgTypes = {
+  ...argTypes,
+  size: {
+    control: { options: ["s", "m", "l"], type: "radio" },
+    defaultValue: "m",
+    description: "define the font size",
+  },
+  strong: {
+    control: { type: "boolean" },
+    defaultValue: false,
+    description: "toggle the strong/bold font type",
+  },
+  underline: {
+    control: { type: "boolean" },
+    defaultValue: false,
+    description: "toggle the underline text decoration",
+  },
+};


### PR DESCRIPTION
## Github issue
closes #34 

## What
adding a `color` property in every typography component that given a color token path value (_ie: `orange.20`_) renders that given DS color as an inline style.

updated the related stories pages with the proper argument controller and a list of values obtained from the design tokens object.

## Note
- also added the lint check in CI for `PR`s and `main` branch
