### PR TITLE
removing B2B

### DIFF
--- a/src/components/Checkbox/Checkbox.css.ts
+++ b/src/components/Checkbox/Checkbox.css.ts
@@ -7,8 +7,6 @@ const size = 16;
 const black = vars.colors.neutral[100];
 const grey = "#B3B3B2";
 const red = vars.colors.alertcolors.error["100"];
-const orange = vars.colors.orange["100"];
-const green = vars.colors.green["100"];
 
 export const wrapper = style({
   alignItems: "center",
@@ -31,26 +29,6 @@ export const checkbox = recipe({
     width: size,
   },
   compoundVariants: [
-    {
-      style: {
-        backgroundColor: orange,
-        borderColor: orange,
-      },
-      variants: {
-        checked: true,
-        variant: "b2b",
-      },
-    },
-    {
-      style: {
-        backgroundColor: green,
-        borderColor: green,
-      },
-      variants: {
-        checked: true,
-        variant: "b2c",
-      },
-    },
     {
       style: {
         backgroundColor: red,
@@ -79,11 +57,6 @@ export const checkbox = recipe({
       true: {
         borderColor: red,
       },
-    },
-    variant: {
-      b2b: {},
-      b2c: {},
-      neutral: {},
     },
   },
 });

--- a/src/components/Checkbox/Checkbox.css.ts
+++ b/src/components/Checkbox/Checkbox.css.ts
@@ -2,8 +2,8 @@ import { globalStyle, style } from "@vanilla-extract/css";
 import { vars } from "../../utils/theme.css";
 import { recipe } from "@vanilla-extract/recipes";
 
-const gap = 8;
-const size = 16;
+const gap = vars.space[100];
+const size = vars.space[200];
 const black = vars.colors.neutral[100];
 const grey = "#B3B3B2";
 const red = vars.colors.alertcolors.error["100"];
@@ -12,7 +12,7 @@ export const wrapper = style({
   alignItems: "center",
   display: "flex",
   flexWrap: "wrap",
-  gap: `0 ${gap}px`,
+  gap: `0 ${gap}`,
   transition: "all 200ms",
 });
 
@@ -73,5 +73,5 @@ export const messageStyle = style({
   color: red,
   flexBasis: "100%",
   margin: 0,
-  marginLeft: size + gap,
+  marginLeft: `calc(${size} + ${gap})`,
 });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -11,7 +11,6 @@ type Props = CheckboxProps & {
   message?: string;
   onChange?: (args: { checked: boolean; value?: string }) => void;
   value?: string;
-  variant?: "neutral" | "b2b" | "b2c";
 };
 
 export const Checkbox = ({
@@ -22,7 +21,6 @@ export const Checkbox = ({
   message,
   onChange,
   value,
-  variant,
 }: Props) => {
   return (
     <CheckboxAria
@@ -34,7 +32,7 @@ export const Checkbox = ({
     >
       <div
         data-id="check-icon"
-        className={checkbox({ checked, disabled, error, variant })}
+        className={checkbox({ checked, disabled, error })}
       >
         {checked && (
           <svg

--- a/src/components/Switch/Switch.css.ts
+++ b/src/components/Switch/Switch.css.ts
@@ -9,7 +9,7 @@ export const base = style({
   alignItems: "center",
   display: "flex",
   fontSize: "1.143rem",
-  gap: "0.572rem",
+  gap: vars.space[100],
   selectors: {
     "&[data-disabled]:hover": {
       cursor: "default",
@@ -24,7 +24,7 @@ const indicatorBase = style({
     content: "",
     display: "block",
     height: "18px",
-    margin: "0.143rem",
+    margin: vars.space[25],
     transition: "all 200ms",
     width: "18px",
   },

--- a/src/stories/Components.Checkbox.stories.tsx
+++ b/src/stories/Components.Checkbox.stories.tsx
@@ -26,12 +26,6 @@ const meta: Meta<typeof Checkbox> = {
       control: "text",
       description: "the value of the checkbox option",
     },
-    variant: {
-      control: "select",
-      defaultValue: "neutral",
-      description: "choose the branding variant",
-      options: ["neutral", "B2B", "B2C"],
-    },
   },
   args: {
     checked: true,
@@ -39,7 +33,6 @@ const meta: Meta<typeof Checkbox> = {
     error: false,
     message: "error message",
     value: "hasElevator",
-    variant: "neutral",
   },
   component: Checkbox,
   title: "Components/Checkbox",
@@ -71,7 +64,6 @@ export const _Checkbox: Story = {
         error={args.error}
         message={args.message}
         value={args.value}
-        variant={args.variant?.toLocaleLowerCase() as never}
       >
         Has elevator
       </Checkbox>


### PR DESCRIPTION
## Figma reference/Github issue
no task, follow up to weekly meeting

## What
- removed the variants in Checkbox component
- updated spacings in some files to use the DS values

## Why
B2B branding is phasing out, while the color remains in the tokens there is no reason for us for maintaining and considering it in the cod
