### PR TITLE
add backstage yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: habitat
+  description: Casavo Design System
+tags:
+  language: Typescript
+spec:
+  type: library
+  lifecycle: production
+  owner: default/write

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,8 +3,13 @@ kind: Component
 metadata:
   name: habitat
   description: Casavo Design System
-tags:
-  language: Typescript
+  tags:
+    - typescript
+  annotations:
+    github.com/project-slug: casavo/habitat
+  links:
+    - url: https://casavo.github.io/habitat/
+      title: Production Storybook
 spec:
   type: library
   lifecycle: production


### PR DESCRIPTION
## Figma reference/Github issue
ArCo meeting follow up
https://www.notion.so/casavo/c57399e600c94a4cba24a424d6ec5b25?pvs=4

## What
adding Backstage catalog config file
https://www.notion.so/casavo/Spotify-Backstage-Usage-89944cf4477d44d6a285d6dbab4635a4?pvs=4

## Why
to enhance the internal software catalog, and to have other projects refer to Habitat as a dependency
