### PR TITLE
fix: add missing component export

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@casavo/habitat",
   "description": "Casavo Design System Library",
   "private": false,
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://github.com/casavo/habitat",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
   Body,
   Description,
   Caption,
+  Inline,
 } from "./components/Typography";
 export { Button } from "./components/Button";
 export { Badge } from "./components/Badge";


### PR DESCRIPTION
## What
add missing component export for `<Inline />`

## Why
you can't import that component in other projects without this