### PR TITLE
feat: build the library also in cjs to support project with jest / not fully support ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "dist"
   ],
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
     "./style.css": "./dist/style.css"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@casavo/habitat",
   "description": "Casavo Design System Library",
   "private": false,
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://github.com/casavo/habitat",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
         path.resolve(__dirname, "src/utils/reset.css.ts"),
         path.resolve(__dirname, "src/index.ts"),
       ],
-      formats: ["es"],
+      formats: ["es","cjs"],
       name: "@casavo/habitat",
     },
     rollupOptions: {


### PR DESCRIPTION
## What

I enable the build of cjs project

## Why

not all project are ready to support ESM only library. 
I think that we should enable the use of the old cjs format to made the dev exprirence easy, without requiring to change build system / test library when start using this library
