### PR TITLE
feat: correctly align checkbox text if it very long, improve props typing

### DIFF
--- a/src/components/Checkbox/Checkbox.css.ts
+++ b/src/components/Checkbox/Checkbox.css.ts
@@ -11,7 +11,6 @@ const red = vars.colors.root.red[600];
 export const wrapper = style({
   alignItems: "center",
   display: "flex",
-  flexWrap: "wrap",
   gap: `0 ${gap}`,
   transition: "all 200ms",
 });

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -2,7 +2,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { expect, describe, vi } from "vitest";
 
 import { Checkbox } from "./Checkbox.tsx";
+import {ComponentProps} from "react";
 
+
+type onChangeType = NonNullable<ComponentProps<typeof Checkbox>['onChange']>
 describe("Checkbox component", () => {
   it("renders", () => {
     const { container } = render(<Checkbox />);
@@ -10,7 +13,7 @@ describe("Checkbox component", () => {
   });
 
   it("renders as selected", () => {
-    const { container } = render(<Checkbox isSelected />);
+    const { container } = render(<Checkbox checked />);
     expect(container.firstChild).toMatchSnapshot();
   });
 
@@ -20,7 +23,7 @@ describe("Checkbox component", () => {
   });
 
   it("calls onChange", async () => {
-    const onChange = vi.fn();
+    const onChange = vi.fn<Parameters<onChangeType>,void>();
     render(<Checkbox onChange={onChange} />);
     const input = screen.getByRole("checkbox");
 
@@ -29,7 +32,8 @@ describe("Checkbox component", () => {
   });
 
   it("calls onChange when is already checked", async () => {
-    const onChange = vi.fn();
+
+    const onChange = vi.fn<Parameters<onChangeType>,void>();
     render(<Checkbox checked={true} onChange={onChange} />);
     const input = screen.getByRole("checkbox");
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -3,15 +3,12 @@ import { Checkbox as CheckboxAria } from "react-aria-components";
 import { checkbox, messageStyle, wrapper } from "./Checkbox.css";
 import { Body } from "../Typography";
 
-type Props = CheckboxProps & {
+type Props = React.PropsWithChildren<{
   checked?: boolean;
-  children?: React.ReactNode;
   disabled?: boolean;
   error?: boolean;
   message?: string;
-  onChange?: (args: { checked: boolean; value?: string }) => void;
-  value?: string;
-};
+} & Omit<CheckboxProps,"isSelected"|"isDisabled"|"children"|"className">>  ;
 
 export const Checkbox = ({
   checked,
@@ -19,16 +16,14 @@ export const Checkbox = ({
   disabled,
   error,
   message,
-  onChange,
-  value,
+    ...props
 }: Props) => {
   return (
     <CheckboxAria
+        {...props}
       isDisabled={disabled}
       isSelected={checked}
       className={wrapper}
-      value={value}
-      onChange={(args) => onChange && onChange(args)}
     >
       <div
         data-id="check-icon"

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -50,18 +50,33 @@ exports[`Checkbox component > renders as selected 1`] = `
 <label
   class="Checkbox_wrapper__1g2c7v70"
   data-rac=""
+  data-selected="true"
 >
   <span
     style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
   >
     <input
+      checked=""
       type="checkbox"
     />
   </span>
   <div
-    class="Checkbox_checkbox__1g2c7v71"
+    class="Checkbox_checkbox__1g2c7v71 Checkbox_checkbox_checked_true__1g2c7v72"
     data-id="check-icon"
-  />
+  >
+    <svg
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4.35982 7.39202L2.87769 8.73317L6.5114 12.7572L13.5542 5.70712L12.1414 4.29291L6.58447 9.85565L4.35982 7.39202Z"
+        fill="white"
+      />
+    </svg>
+  </div>
   <p
     class="Typography__3igy4nb Typography_base__3igy4na Typography_BodyStyle_noMargin_true__3igy4nc Typography_BodyStyle_size_m__3igy4ne"
   />

--- a/src/stories/Components.Checkbox.stories.tsx
+++ b/src/stories/Components.Checkbox.stories.tsx
@@ -2,8 +2,11 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Checkbox } from "../components/Checkbox";
 import { StoryLayout } from "./components/StoryLayout";
+import {ComponentProps} from "react";
 
-const meta: Meta<typeof Checkbox> = {
+type StoryProps = ComponentProps<typeof Checkbox> &{ text:string} 
+
+const meta: Meta<StoryProps> = {
   argTypes: {
     checked: {
       control: "boolean",
@@ -32,7 +35,8 @@ const meta: Meta<typeof Checkbox> = {
     disabled: false,
     error: false,
     message: "error message",
-    value: "hasElevator",
+    text: "Has elevator",
+    value: "hasElevator"
   },
   component: Checkbox,
   title: "Components/Checkbox",
@@ -46,7 +50,7 @@ const description = (
 );
 
 export default meta;
-type Story = StoryObj<typeof Checkbox>;
+type Story = StoryObj<StoryProps>;
 
 export const _Checkbox: Story = {
   render: ({ ...args }) => (
@@ -58,14 +62,13 @@ export const _Checkbox: Story = {
       usage={"<Checkbox checked={false}>Has elevator</Checkbox>"}
     >
       <Checkbox
-        {...args}
         checked={args.checked}
         disabled={args.disabled}
         error={args.error}
         message={args.message}
         value={args.value}
       >
-        Has elevator
+        {args.text}
       </Checkbox>
     </StoryLayout>
   ),


### PR DESCRIPTION
## What

when the text is very long, the chebox and the text went on 2 lines:
![Screenshot 2024-04-18 at 15 41 15](https://github.com/casavo/habitat/assets/67365669/209edbb1-68a5-4811-b66b-4851a6d7ed12)

with this pr the text can go on multiple lines, and the checbox will remain centered with the text.

+ I removed some duplicate props and use the definition type defined by react arai when possibile.

