### PR TITLE
feat: use transparent checkbox image to be secure the componet size remain the same

### DIFF
--- a/src/components/Checkbox/Checkbox.css.ts
+++ b/src/components/Checkbox/Checkbox.css.ts
@@ -23,6 +23,7 @@ export const checkbox = recipe({
     border: `1px solid ${grey}`,
     borderRadius: 4,
     display: "flex",
+    flexShrink:0,
     height: size,
     justifyContent: " center",
     transition: "all 200ms",

--- a/src/components/Checkbox/Checkbox.css.ts
+++ b/src/components/Checkbox/Checkbox.css.ts
@@ -5,7 +5,8 @@ import { recipe } from "@vanilla-extract/recipes";
 const gap = vars.space[100];
 const size = vars.space[200];
 const black = vars.colors.root.neutral[600];
-const grey = "#B3B3B2";
+const grey = vars.colors.root.neutral[300];
+const white = vars.colors.root.neutral[100]
 const red = vars.colors.root.red[600];
 
 export const wrapper = style({
@@ -48,7 +49,7 @@ export const checkbox = recipe({
     },
     disabled: {
       true: {
-        backgroundColor: "#E8E8E8",
+        backgroundColor: white,
         borderColor: grey,
       },
     },

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -30,7 +30,7 @@ export const Checkbox = ({
         data-id="check-icon"
         className={checkbox({ checked, disabled, error })}
       >
-          <svg
+        {checked && <svg
             xmlns="http://www.w3.org/2000/svg"
             width="16"
             height="16"
@@ -39,9 +39,10 @@ export const Checkbox = ({
           >
             <path
               d="M4.35982 7.39202L2.87769 8.73317L6.5114 12.7572L13.5542 5.70712L12.1414 4.29291L6.58447 9.85565L4.35982 7.39202Z"
-              fill= {checked ? vars.colors.root.neutral[0] : "none"}
+              fill= {vars.colors.root.neutral[0]}
             />
           </svg>
+        }
       </div>
       <Body noMargin={true}>{children}</Body>
       {error && (

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -2,14 +2,19 @@ import type { CheckboxProps } from "react-aria-components";
 import { Checkbox as CheckboxAria } from "react-aria-components";
 import { checkbox, messageStyle, wrapper } from "./Checkbox.css";
 import { Body } from "../Typography";
-import {vars} from "../../utils/theme.css.ts";
+import { vars } from "../../utils/theme.css.ts";
 
-type Props = React.PropsWithChildren<{
-  checked?: boolean;
-  disabled?: boolean;
-  error?: boolean;
-  message?: string;
-} & Omit<CheckboxProps,"isSelected"|"isDisabled"|"children"|"className">>  ;
+type Props = React.PropsWithChildren<
+  {
+    checked?: boolean;
+    disabled?: boolean;
+    error?: boolean;
+    message?: string;
+  } & Omit<
+    CheckboxProps,
+    "isSelected" | "isDisabled" | "children" | "className"
+  >
+>;
 
 export const Checkbox = ({
   checked,
@@ -17,11 +22,11 @@ export const Checkbox = ({
   disabled,
   error,
   message,
-    ...props
+  ...props
 }: Props) => {
   return (
     <CheckboxAria
-        {...props}
+      {...props}
       isDisabled={disabled}
       isSelected={checked}
       className={wrapper}
@@ -30,7 +35,8 @@ export const Checkbox = ({
         data-id="check-icon"
         className={checkbox({ checked, disabled, error })}
       >
-        {checked && <svg
+        {checked && (
+          <svg
             xmlns="http://www.w3.org/2000/svg"
             width="16"
             height="16"
@@ -39,15 +45,15 @@ export const Checkbox = ({
           >
             <path
               d="M4.35982 7.39202L2.87769 8.73317L6.5114 12.7572L13.5542 5.70712L12.1414 4.29291L6.58447 9.85565L4.35982 7.39202Z"
-              fill= {vars.colors.root.neutral[0]}
+              fill={vars.colors.root.neutral[0]}
             />
           </svg>
-        }
+        )}
       </div>
       <Body noMargin={true}>{children}</Body>
       {error && (
         <div className={messageStyle}>
-          <Body noMargin size="s" color={'root.red.600'}>
+          <Body noMargin size="s" color={"root.red.600"}>
             {message || "error message"}
           </Body>
         </div>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -2,6 +2,7 @@ import type { CheckboxProps } from "react-aria-components";
 import { Checkbox as CheckboxAria } from "react-aria-components";
 import { checkbox, messageStyle, wrapper } from "./Checkbox.css";
 import { Body } from "../Typography";
+import {vars} from "../../utils/theme.css.ts";
 
 type Props = React.PropsWithChildren<{
   checked?: boolean;
@@ -29,7 +30,6 @@ export const Checkbox = ({
         data-id="check-icon"
         className={checkbox({ checked, disabled, error })}
       >
-        {checked && (
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="16"
@@ -39,15 +39,14 @@ export const Checkbox = ({
           >
             <path
               d="M4.35982 7.39202L2.87769 8.73317L6.5114 12.7572L13.5542 5.70712L12.1414 4.29291L6.58447 9.85565L4.35982 7.39202Z"
-              fill="white"
+              fill= {checked ? vars.colors.root.neutral[0] : "none"}
             />
           </svg>
-        )}
       </div>
       <Body noMargin={true}>{children}</Body>
       {error && (
         <div className={messageStyle}>
-          <Body noMargin size="s" color={error && "root.red.600"}>
+          <Body noMargin size="s" color={'root.red.600'}>
             {message || "error message"}
           </Body>
         </div>

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -15,20 +15,7 @@ exports[`Checkbox component > renders 1`] = `
   <div
     class="Checkbox_checkbox__1g2c7v71"
     data-id="check-icon"
-  >
-    <svg
-      fill="none"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M4.35982 7.39202L2.87769 8.73317L6.5114 12.7572L13.5542 5.70712L12.1414 4.29291L6.58447 9.85565L4.35982 7.39202Z"
-        fill="none"
-      />
-    </svg>
-  </div>
+  />
   <p
     class="Typography__3igy4nb Typography_base__3igy4na Typography_BodyStyle_noMargin_true__3igy4nc Typography_BodyStyle_size_m__3igy4ne"
   />
@@ -52,20 +39,7 @@ exports[`Checkbox component > renders as disabled 1`] = `
   <div
     class="Checkbox_checkbox__1g2c7v71 Checkbox_checkbox_disabled_true__1g2c7v73"
     data-id="check-icon"
-  >
-    <svg
-      fill="none"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M4.35982 7.39202L2.87769 8.73317L6.5114 12.7572L13.5542 5.70712L12.1414 4.29291L6.58447 9.85565L4.35982 7.39202Z"
-        fill="none"
-      />
-    </svg>
-  </div>
+  />
   <p
     class="Typography__3igy4nb Typography_base__3igy4na Typography_BodyStyle_noMargin_true__3igy4nc Typography_BodyStyle_size_m__3igy4ne"
   />

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -15,7 +15,20 @@ exports[`Checkbox component > renders 1`] = `
   <div
     class="Checkbox_checkbox__1g2c7v71"
     data-id="check-icon"
-  />
+  >
+    <svg
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4.35982 7.39202L2.87769 8.73317L6.5114 12.7572L13.5542 5.70712L12.1414 4.29291L6.58447 9.85565L4.35982 7.39202Z"
+        fill="none"
+      />
+    </svg>
+  </div>
   <p
     class="Typography__3igy4nb Typography_base__3igy4na Typography_BodyStyle_noMargin_true__3igy4nc Typography_BodyStyle_size_m__3igy4ne"
   />

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -52,7 +52,20 @@ exports[`Checkbox component > renders as disabled 1`] = `
   <div
     class="Checkbox_checkbox__1g2c7v71 Checkbox_checkbox_disabled_true__1g2c7v73"
     data-id="check-icon"
-  />
+  >
+    <svg
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4.35982 7.39202L2.87769 8.73317L6.5114 12.7572L13.5542 5.70712L12.1414 4.29291L6.58447 9.85565L4.35982 7.39202Z"
+        fill="none"
+      />
+    </svg>
+  </div>
   <p
     class="Typography__3igy4nb Typography_base__3igy4na Typography_BodyStyle_noMargin_true__3igy4nc Typography_BodyStyle_size_m__3igy4ne"
   />
@@ -86,7 +99,7 @@ exports[`Checkbox component > renders as selected 1`] = `
     >
       <path
         d="M4.35982 7.39202L2.87769 8.73317L6.5114 12.7572L13.5542 5.70712L12.1414 4.29291L6.58447 9.85565L4.35982 7.39202Z"
-        fill="white"
+        fill="var(--colors-root-neutral-0__w88n3727)"
       />
     </svg>
   </div>

--- a/src/stories/Components.Checkbox.stories.tsx
+++ b/src/stories/Components.Checkbox.stories.tsx
@@ -4,14 +4,10 @@ import { Checkbox } from "../components/Checkbox";
 import { StoryLayout } from "./components/StoryLayout";
 import {ComponentProps} from "react";
 
-type StoryProps = ComponentProps<typeof Checkbox> &{ text:string} 
+type StoryProps = Omit<ComponentProps<typeof Checkbox>,'checked'> &{ text:string}
 
 const meta: Meta<StoryProps> = {
   argTypes: {
-    checked: {
-      control: "boolean",
-      description: "toggle the state",
-    },
     disabled: {
       control: "boolean",
       description: "toggle the standard disabled state",
@@ -31,7 +27,6 @@ const meta: Meta<StoryProps> = {
     },
   },
   args: {
-    checked: true,
     disabled: false,
     error: false,
     message: "error message",
@@ -61,8 +56,8 @@ export const _Checkbox: Story = {
       title="Components/Checkbox"
       usage={"<Checkbox checked={false}>Has elevator</Checkbox>"}
     >
-      <Checkbox
-        checked={args.checked}
+            <Checkbox
+        checked={false}
         disabled={args.disabled}
         error={args.error}
         message={args.message}
@@ -70,6 +65,16 @@ export const _Checkbox: Story = {
       >
         {args.text}
       </Checkbox>
+        <Checkbox
+            checked={true}
+            disabled={args.disabled}
+            error={args.error}
+            message={args.message}
+            value={args.value}
+        >
+          {args.text}
+        </Checkbox>
+
     </StoryLayout>
   ),
 };


### PR DESCRIPTION
## What

with long text the checkbox is resized giving priority to the text. 

![Screenshot 2024-04-22 at 16 01 21](https://github.com/casavo/habitat/assets/67365669/84f64d90-c184-47e1-b861-1492b6220098)

i set flexShrink to 0 to avoid the shrinking.

bonus: removed some hardcoded colors
