### PR TITLE
feat: Expose theme contract and default values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vanilla-extract/css": "1.15.2",
         "@vanilla-extract/recipes": "0.5.3",
         "react-aria-components": "1.0.0-beta.1"
       },
@@ -56,6 +55,7 @@
         "node": "^18 || ^19 || ^20"
       },
       "peerDependencies": {
+        "@vanilla-extract/css": "^1.15.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
-    "@vanilla-extract/css": "1.15.2",
     "@vanilla-extract/recipes": "0.5.3",
     "react-aria-components": "1.0.0-beta.1"
   },
   "peerDependencies": {
+    "@vanilla-extract/css": "^1.15.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/components/Badge/Badge.css.ts
+++ b/src/components/Badge/Badge.css.ts
@@ -1,41 +1,41 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 import { recipe } from "@vanilla-extract/recipes";
-import { vars } from "../../utils/theme.css";
+import { themeContract } from "../../utils/theme.css";
 
 export const BadgeContainer = recipe({
   base: {
     alignItems: "center",
-    borderRadius: vars.corners[300],
+    borderRadius: themeContract.corners[300],
     display: "inline-flex",
-    gap: vars.space[100],
+    gap: themeContract.space[100],
     justifyContent: "center",
-    padding: `${vars.space[100]} ${vars.space[200]}`,
+    padding: `${themeContract.space[100]} ${themeContract.space[200]}`,
   },
   variants: {
     theme: {
       dark: {
-        backgroundColor: vars.colors.root.darkgreen[700],
-        color: vars.colors.root.neutral[0],
-        fill: vars.colors.root.neutral[0],
+        backgroundColor: themeContract.colors.root.darkgreen[700],
+        color: themeContract.colors.root.neutral[0],
+        fill: themeContract.colors.root.neutral[0],
       },
       light: {
-        backgroundColor: vars.colors.root.offwhite[100],
-        color: vars.colors.root.neutral[600],
-        fill: vars.colors.root.neutral[600],
+        backgroundColor: themeContract.colors.root.offwhite[100],
+        color: themeContract.colors.root.neutral[600],
+        fill: themeContract.colors.root.neutral[600],
       },
     },
     status: {
       error: {
-        backgroundColor: vars.colors.root.red[200],
-        color: vars.colors.root.red[600],
+        backgroundColor: themeContract.colors.root.red[200],
+        color: themeContract.colors.root.red[600],
       },
       success: {
-        backgroundColor: vars.colors.root.green[200],
-        color: vars.colors.root.green[600],
+        backgroundColor: themeContract.colors.root.green[200],
+        color: themeContract.colors.root.green[600],
       },
       warning: {
-        backgroundColor: vars.colors.root.yellow[200],
-        color: vars.colors.root.yellow[600],
+        backgroundColor: themeContract.colors.root.yellow[200],
+        color: themeContract.colors.root.yellow[600],
       },
     },
   },

--- a/src/components/Button/Button.css.ts
+++ b/src/components/Button/Button.css.ts
@@ -1,15 +1,17 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 import { recipe } from "@vanilla-extract/recipes";
-import { vars } from "../../utils/theme.css";
+import { themeContract } from "../../utils/theme.css";
 import { keyframes, style } from "@vanilla-extract/css";
 
-const black = vars.colors.buttons.light.background.default;
-const white = vars.colors.buttons.dark.background.default;
+const black = themeContract.colors.buttons.light.background.default;
+const white = themeContract.colors.buttons.dark.background.default;
 
-const background = vars.colors.buttons.dark.background.disabled;
-const activeDark = vars.colors.buttons.dark.background["active, pressed"];
-const disabled = vars.colors.buttons.dark.text.disabled;
-const activeLight = vars.colors.buttons.light.background["active, pressed"];
+const background = themeContract.colors.buttons.dark.background.disabled;
+const activeDark =
+  themeContract.colors.buttons.dark.background["active, pressed"];
+const disabled = themeContract.colors.buttons.dark.text.disabled;
+const activeLight =
+  themeContract.colors.buttons.light.background["active, pressed"];
 
 const rotate = keyframes({
   "0%": { transform: "rotate(0deg)" },
@@ -25,11 +27,11 @@ export const ButtonContainer = recipe({
   base: {
     alignItems: "center",
     alignSelf: "stretch",
-    borderRadius: vars.corners[50],
+    borderRadius: themeContract.corners[50],
     display: "inline-flex",
-    gap: vars.space[100],
+    gap: themeContract.space[100],
     justifyContent: "center",
-    padding: `${vars.space[150]} ${vars.space[200]}`,
+    padding: `${themeContract.space[150]} ${themeContract.space[200]}`,
     cursor: "pointer",
     ":disabled": {
       cursor: "not-allowed",

--- a/src/components/Checkbox/Checkbox.css.ts
+++ b/src/components/Checkbox/Checkbox.css.ts
@@ -1,13 +1,13 @@
 import { globalStyle, style } from "@vanilla-extract/css";
-import { vars } from "../../utils/theme.css";
+import { themeContract } from "../../utils/theme.css";
 import { recipe } from "@vanilla-extract/recipes";
 
-const gap = vars.space[100];
-const size = vars.space[200];
-const checked = vars.colors.root.orange[500];
-const grey = vars.colors.root.neutral[300];
-const white = vars.colors.root.neutral[100]
-const error = vars.colors.root.red[600];
+const gap = themeContract.space[100];
+const size = themeContract.space[200];
+const checked = themeContract.colors.root.orange[500];
+const grey = themeContract.colors.root.neutral[300];
+const white = themeContract.colors.root.neutral[100];
+const error = themeContract.colors.root.red[600];
 
 export const wrapper = style({
   alignItems: "center",
@@ -19,11 +19,11 @@ export const wrapper = style({
 export const checkbox = recipe({
   base: {
     alignItems: "center",
-    backgroundColor: vars.colors.root.neutral[0],
+    backgroundColor: themeContract.colors.root.neutral[0],
     border: `1px solid ${grey}`,
     borderRadius: 4,
     display: "flex",
-    flexShrink:0,
+    flexShrink: 0,
     height: size,
     justifyContent: " center",
     transition: "all 200ms",

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -2,7 +2,7 @@ import type { CheckboxProps } from "react-aria-components";
 import { Checkbox as CheckboxAria } from "react-aria-components";
 import { checkbox, messageStyle, wrapper } from "./Checkbox.css";
 import { Body } from "../Typography";
-import { vars } from "../../utils/theme.css.ts";
+import { themeContract } from "../../utils/theme.css.ts";
 
 type Props = React.PropsWithChildren<
   {
@@ -45,7 +45,11 @@ export const Checkbox = ({
           >
             <path
               d="M4.35982 7.39202L2.87769 8.73317L6.5114 12.7572L13.5542 5.70712L12.1414 4.29291L6.58447 9.85565L4.35982 7.39202Z"
-              fill={disabled ? vars.colors.root.neutral[300] : vars.colors.root.neutral[0]}
+              fill={
+                disabled
+                  ? themeContract.colors.root.neutral[300]
+                  : themeContract.colors.root.neutral[0]
+              }
             />
           </svg>
         )}

--- a/src/components/Spinner/Spinner.css.ts
+++ b/src/components/Spinner/Spinner.css.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 import { keyframes } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
-import { vars } from "../../utils/theme.css";
+import { themeContract } from "../../utils/theme.css";
 
 const sizes: Record<"large" | "medium" | "small", number> = {
   large: 28,
@@ -90,7 +90,7 @@ export const Circle = recipe({
         variant: "primary",
       },
       style: {
-        borderColor: vars.colors.root.neutral[0],
+        borderColor: themeContract.colors.root.neutral[0],
       },
     },
     {
@@ -99,7 +99,7 @@ export const Circle = recipe({
         variant: "secondary" || "tertiary",
       },
       style: {
-        borderColor: vars.colors.root.neutral[600],
+        borderColor: themeContract.colors.root.neutral[600],
       },
     },
     {
@@ -108,7 +108,7 @@ export const Circle = recipe({
         variant: "primary",
       },
       style: {
-        borderColor: vars.colors.root.neutral[600],
+        borderColor: themeContract.colors.root.neutral[600],
       },
     },
     {
@@ -117,7 +117,7 @@ export const Circle = recipe({
         variant: "secondary" || "tertiary",
       },
       style: {
-        borderColor: vars.colors.root.neutral[0],
+        borderColor: themeContract.colors.root.neutral[0],
       },
     },
   ],
@@ -176,7 +176,7 @@ export const Spin = recipe({
         variant: "primary",
       },
       style: {
-        borderTopColor: vars.colors.root.neutral[0],
+        borderTopColor: themeContract.colors.root.neutral[0],
       },
     },
     {
@@ -185,7 +185,7 @@ export const Spin = recipe({
         variant: "secondary" || "tertiary",
       },
       style: {
-        borderTopColor: vars.colors.root.neutral[600],
+        borderTopColor: themeContract.colors.root.neutral[600],
       },
     },
     {
@@ -194,7 +194,7 @@ export const Spin = recipe({
         variant: "primary",
       },
       style: {
-        borderTopColor: vars.colors.root.neutral[600],
+        borderTopColor: themeContract.colors.root.neutral[600],
       },
     },
     {
@@ -203,7 +203,7 @@ export const Spin = recipe({
         variant: "secondary" || "tertiary",
       },
       style: {
-        borderTopColor: vars.colors.root.neutral[0],
+        borderTopColor: themeContract.colors.root.neutral[0],
       },
     },
   ],

--- a/src/components/Switch/Switch.css.ts
+++ b/src/components/Switch/Switch.css.ts
@@ -1,5 +1,5 @@
 import { recipe } from "@vanilla-extract/recipes";
-import { vars } from "../../utils/theme.css";
+import { themeContract } from "../../utils/theme.css";
 import { style } from "@vanilla-extract/css";
 
 export const base = style({
@@ -9,7 +9,7 @@ export const base = style({
   alignItems: "center",
   display: "flex",
   fontSize: "1.143rem",
-  gap: vars.space[100],
+  gap: themeContract.space[100],
   selectors: {
     "&[data-disabled]:hover": {
       cursor: "default",
@@ -19,16 +19,16 @@ export const base = style({
 
 const indicatorBase = style({
   "::before": {
-    background: vars.colors.root.neutral[0],
+    background: themeContract.colors.root.neutral[0],
     borderRadius: "16px",
     content: "",
     display: "block",
     height: "18px",
-    margin: vars.space[25],
+    margin: themeContract.space[25],
     transition: "all 200ms",
     width: "18px",
   },
-  background: vars.colors.root.neutral[300],
+  background: themeContract.colors.root.neutral[300],
   border: "none",
   // atm missing in vars
   borderRadius: "11px",
@@ -37,20 +37,20 @@ const indicatorBase = style({
 
   selectors: {
     [`${base}[data-selected] &`]: {
-      background: vars.colors.brand.primary,
-      borderColor: vars.colors.brand.primary,
+      background: themeContract.colors.brand.primary,
+      borderColor: themeContract.colors.brand.primary,
     },
     [`${base}[data-selected] &:before`]: {
-      background: vars.colors.root.neutral[0],
+      background: themeContract.colors.root.neutral[0],
       transform: "translateX(100%)",
     },
     [`${base}[data-disabled] &`]: {
-      background: vars.colors.root.neutral[100],
-      borderColor: vars.colors.root.neutral[100],
+      background: themeContract.colors.root.neutral[100],
+      borderColor: themeContract.colors.root.neutral[100],
     },
     [`${base}[data-selected][data-disabled] &`]: {
-      background: vars.colors.root.orange[400],
-      borderColor: vars.colors.root.orange[400]
+      background: themeContract.colors.root.orange[400],
+      borderColor: themeContract.colors.root.orange[400],
     },
   },
   transition: "all 300ms",

--- a/src/components/Typography/Typography.css.ts
+++ b/src/components/Typography/Typography.css.ts
@@ -1,6 +1,6 @@
 import { recipe } from "@vanilla-extract/recipes";
 import { mq } from "../../utils/mediaqueries";
-import { vars } from "../../utils/theme.css";
+import { themeContract } from "../../utils/theme.css";
 import { fontFace, globalStyle, style } from "@vanilla-extract/css";
 
 const Bagoss = fontFace({
@@ -16,7 +16,7 @@ const noMargin = {
 };
 
 globalStyle("a", {
-  color: vars.colors.root.neutral[600],
+  color: themeContract.colors.root.neutral[600],
 });
 
 export const HeadingsStyle = recipe({
@@ -34,7 +34,7 @@ export const HeadingsStyle = recipe({
         },
         fontFamily: Bagoss,
         fontSize: "40px !important",
-        marginBottom: `${vars.space[600]} !important`,
+        marginBottom: `${themeContract.space[600]} !important`,
       },
     },
     element: {
@@ -44,7 +44,7 @@ export const HeadingsStyle = recipe({
         },
         fontFamily: Bagoss,
         fontSize: 36,
-        marginBottom: vars.space[400],
+        marginBottom: themeContract.space[400],
       },
       h2: {
         "@media": {
@@ -52,7 +52,7 @@ export const HeadingsStyle = recipe({
         },
         fontFamily: Bagoss,
         fontSize: 32,
-        marginBottom: vars.space[300],
+        marginBottom: themeContract.space[300],
       },
       h3: {
         "@media": {
@@ -62,7 +62,7 @@ export const HeadingsStyle = recipe({
         fontSize: 24,
         fontWeight: 500,
         lineHeight: 1.5,
-        marginBottom: vars.space[300],
+        marginBottom: themeContract.space[300],
       },
       h4: {
         "@media": {
@@ -72,7 +72,7 @@ export const HeadingsStyle = recipe({
         fontSize: 20,
         fontWeight: 500,
         lineHeight: 1.5,
-        marginBottom: vars.space[300],
+        marginBottom: themeContract.space[300],
       },
       h5: {
         "@media": {
@@ -82,14 +82,14 @@ export const HeadingsStyle = recipe({
         fontSize: 16,
         fontWeight: 500,
         lineHeight: 1.5,
-        marginBottom: vars.space[200],
+        marginBottom: themeContract.space[200],
       },
       h6: {
         fontFamily: Inter,
         fontSize: 16,
         fontWeight: 500,
         lineHeight: 1.5,
-        marginBottom: vars.space[200],
+        marginBottom: themeContract.space[200],
       },
     },
     noMargin,
@@ -101,7 +101,7 @@ const base = style({
   fontFamily: Inter,
   fontWeight: 400,
   lineHeight: 1.5,
-  marginBottom: vars.space[200],
+  marginBottom: themeContract.space[200],
   textDecoration: "none",
   whiteSpace,
 });

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { vars } from "../../utils/theme.css";
+import { themeContract } from "../../utils/theme.css";
 
 import { BodyStyle, HeadingsStyle, InlineStyle } from "./Typography.css";
 
@@ -11,7 +11,7 @@ type NestedKeyOf<ObjectType extends object> = {
     : `${Key}`;
 }[keyof ObjectType & string];
 
-type Colors = NestedKeyOf<typeof vars.colors>;
+type Colors = NestedKeyOf<typeof themeContract.colors>;
 
 type BaseProps = {
   children?: React.ReactNode | string;
@@ -49,10 +49,11 @@ const conditionalAttrs = (html?: string, color?: Colors) => {
  * variables, it returns the corresponding color as CSS variable value
  */
 const getColor = (color?: Colors) => {
-  const fallback = vars.colors.root.neutral[600];
+  const fallback = themeContract.colors.root.neutral[600];
   const paths = color?.split(".");
   const result =
-    paths && paths.reduce((acc, path) => acc[path as never], vars.colors);
+    paths &&
+    paths.reduce((acc, path) => acc[path as never], themeContract.colors);
   return result || fallback;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-export { HabitatTheme, vars } from "./utils/theme.css";
+export {
+  HabitatTheme,
+  themeContract as vars,
+  defaultThemeValues,
+} from "./utils/theme.css";
 export { H1, H2, H3, H4, H5, H6, Body, Inline } from "./components/Typography";
 export { Button } from "./components/Button";
 export { Badge } from "./components/Badge";

--- a/src/stories/components/StoryLayout.tsx
+++ b/src/stories/components/StoryLayout.tsx
@@ -1,5 +1,5 @@
 import "./../../utils/reset.css";
-import { HabitatTheme, vars } from "./../../utils/theme.css";
+import { HabitatTheme, themeContract } from "./../../utils/theme.css";
 import { H1, H2, H4, Body } from "../../components/Typography";
 // import { Source } from "@storybook/blocks";
 import { SupportedLanguage } from "@storybook/components";
@@ -14,9 +14,9 @@ type Props = {
   usage?: string;
 };
 
-const Spacer = () => <hr style={{ margin: `${vars.space[200]} 0` }} />;
+const Spacer = () => <hr style={{ margin: `${themeContract.space[200]} 0` }} />;
 const Hgroup = ({ children }: { children: React.ReactNode }) => (
-  <hgroup style={{ marginBottom: vars.space[200] }}>{children}</hgroup>
+  <hgroup style={{ marginBottom: themeContract.space[200] }}>{children}</hgroup>
 );
 
 /**

--- a/src/stories/utils/colors.ts
+++ b/src/stories/utils/colors.ts
@@ -1,4 +1,4 @@
-import { vars } from "../../utils/theme.css";
+import { themeContract } from "../../utils/theme.css";
 
 const findKeys = (obj: never, prefix: string = ""): string[] => {
   const keys = Object.keys(obj).map((key) => {
@@ -12,5 +12,5 @@ const findKeys = (obj: never, prefix: string = ""): string[] => {
 };
 
 export const getColors = (): string[] => {
-  return findKeys(vars.colors as never);
+  return findKeys(themeContract.colors as never);
 };

--- a/src/utils/theme.css.ts
+++ b/src/utils/theme.css.ts
@@ -1,13 +1,47 @@
-import { createTheme } from "@vanilla-extract/css";
+import { createTheme, createThemeContract } from "@vanilla-extract/css";
 
 import { mq } from "./mediaqueries";
 import { corners } from "./corners";
 import { space } from "./spacing";
 import { colors } from "./colors";
 
-export const [HabitatTheme, vars] = createTheme({
+type ThemeJsonValue = string | { [key: string]: ThemeJsonValue };
+
+type ThemeJsonObject = Record<string, ThemeJsonValue>;
+
+type NullifiyJsonObject<T> = {
+  [K in keyof T]: T[K] extends ThemeJsonObject
+    ? NullifiyJsonObject<T[K]>
+    : null;
+};
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
+const nullifyThemeLeaves = <T extends ThemeJsonObject>(
+  themeValues: T
+): NullifiyJsonObject<T> => {
+  return Object.entries(themeValues).reduce<DeepPartial<NullifiyJsonObject<T>>>(
+    (acc, [key, value]) => {
+      if (value === null || typeof value !== "object") {
+        return { ...acc, [key]: null };
+      }
+
+      return { ...acc, [key]: nullifyThemeLeaves(value) };
+    },
+    {}
+  ) as NullifiyJsonObject<T>;
+};
+
+export const defaultThemeValues = {
   colors,
   corners,
   mq,
   space,
-});
+};
+
+const contractSkeleton = nullifyThemeLeaves(defaultThemeValues);
+export const themeContract = createThemeContract(contractSkeleton);
+
+export const HabitatTheme = createTheme(themeContract, defaultThemeValues);

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,1 +1,1 @@
-export { HabitatTheme, vars } from "./theme.css";
+export { HabitatTheme, themeContract as vars } from "./theme.css";

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "vitest";
 
 import { mq } from "./mediaqueries";
-import { vars, HabitatTheme } from "./theme.css";
+import { themeContract, HabitatTheme } from "./theme.css";
 
 describe("General utilities", () => {
   it("expect media queries to have correct values", () => {
@@ -15,10 +15,10 @@ describe("General utilities", () => {
   });
 
   it("expect theme vars to have been created correctly", () => {
-    expect(vars.colors).toBeTypeOf("object");
-    expect(vars.space).toBeTypeOf("object");
-    expect(vars.mq).toBeTypeOf("object");
-    expect(vars.corners).toBeTypeOf("object");
+    expect(themeContract.colors).toBeTypeOf("object");
+    expect(themeContract.space).toBeTypeOf("object");
+    expect(themeContract.mq).toBeTypeOf("object");
+    expect(themeContract.corners).toBeTypeOf("object");
   });
 
   it("expect HabitatTheme to be a class name", () => {


### PR DESCRIPTION
## Figma reference/Github issue

_link to the involved component(s) on the Figma board_

## What

POC(proof of concept):
Besides exposing the vanilla extract Habitat default theme, we also expose a theme contract that can be implemented by the consumers and the default Habitat theme raw values so that a consumer can override only fragment of it.

`vanilla-extract/css` becomes a peer dep as now the lib is themable and the consumer should have this depedency installed in order to diverge from the default theme

## [OPTIONAL] Why


POC for the ucsc integration


## [OPTIONAL] How to test/Reproduction steps

_if the the PR requires particular steps to allow other developer to test it, please describe it here_

## [OPTIONAL] Notes

_any eventual notes not covered in previous sections_

## Release checklist

- [ ] assign this PR to yourself
- [ ] add meaningful labels
- [ ] add at least 2 reviewers

(_Chromatic approvals, unit tests outcome and devs approval are already verified automatically_)
