### PR TITLE
Refactor/button use latest tokens

### DIFF
--- a/src/components/Button/Button.css.ts
+++ b/src/components/Button/Button.css.ts
@@ -3,16 +3,6 @@ import { recipe } from "@vanilla-extract/recipes";
 import { themeContract } from "../../utils/themes";
 import { keyframes, style } from "@vanilla-extract/css";
 
-const black = themeContract.colors.buttons.light.background.default;
-const white = themeContract.colors.buttons.dark.background.default;
-
-const background = themeContract.colors.buttons.dark.background.disabled;
-const activeDark =
-  themeContract.colors.buttons.dark.background["active, pressed"];
-const disabled = themeContract.colors.buttons.dark.text.disabled;
-const activeLight =
-  themeContract.colors.buttons.light.background["active, pressed"];
-
 const rotate = keyframes({
   "0%": { transform: "rotate(0deg)" },
   "100%": { transform: "rotate(360deg)" },
@@ -41,14 +31,71 @@ export const ButtonContainer = recipe({
     },
   },
   variants: {
-    theme: {
-      dark: {},
-      light: {},
-    },
     variant: {
-      primary: {},
-      secondary: {},
-      tertiary: {},
+      primary: {
+        backgroundColor: themeContract.colors.buttons.background.default,
+        color: themeContract.colors.buttons.text.inverted,
+        fill: themeContract.colors.buttons.text.inverted,
+        border: `1px solid ${themeContract.colors.buttons.border.default}`,
+        ":hover": {
+          backgroundColor: themeContract.colors.buttons.background.hover,
+          border: `1px solid ${themeContract.colors.buttons.border.hover}`,
+        },
+        ":active": {
+          backgroundColor:
+            themeContract.colors.buttons.background["active, pressed"],
+          border: `1px solid ${themeContract.colors.buttons.border["active, pressed"]}`,
+        },
+        ":disabled": {
+          backgroundColor: themeContract.colors.buttons.background.disabled,
+          border: `1px solid ${themeContract.colors.buttons.border.disabled}`,
+          color: themeContract.colors.buttons.text.disabled,
+          fill: themeContract.colors.buttons.text.disabled,
+        },
+      },
+      secondary: {
+        backgroundColor: "transparent",
+        color: themeContract.colors.buttons.text.primary,
+        fill: themeContract.colors.buttons.text.primary,
+        border: `1px solid ${themeContract.colors.buttons.border.default}`,
+        ":hover": {
+          backgroundColor: themeContract.colors.buttons.background.default,
+          color: themeContract.colors.buttons.text.inverted,
+          fill: themeContract.colors.buttons.text.inverted,
+        },
+        ":active": {
+          backgroundColor:
+            themeContract.colors.buttons.background["active, pressed"],
+          color: themeContract.colors.buttons.text.inverted,
+          border: `1px solid ${themeContract.colors.buttons.border["active, pressed"]}`,
+        },
+        ":disabled": {
+          backgroundColor: themeContract.colors.buttons.background.disabled,
+          border: `1px solid ${themeContract.colors.buttons.border.disabled}`,
+          color: themeContract.colors.buttons.text.disabled,
+          fill: themeContract.colors.buttons.text.disabled,
+        },
+      },
+      tertiary: {
+        backgroundColor: "transparent",
+        border: "none",
+        color: themeContract.colors.buttons.text.primary,
+        fill: themeContract.colors.buttons.text.primary,
+        ":hover": {
+          backgroundColor:
+            themeContract.colors.buttons.background["hover-tertiary"],
+          border: themeContract.colors.buttons.border["hover-tertiary"],
+        },
+        ":active": {
+          backgroundColor:
+            themeContract.colors.buttons.background["hover-tertiary"],
+          border: `1px solid ${themeContract.colors.buttons.border["active, pressed"]}`,
+        },
+        ":disabled": {
+          color: themeContract.colors.buttons.text.disabled,
+          fill: themeContract.colors.buttons.text.disabled,
+        },
+      },
     },
     size: {
       small: {
@@ -70,160 +117,4 @@ export const ButtonContainer = recipe({
       },
     },
   },
-  compoundVariants: [
-    {
-      variants: {
-        theme: "dark",
-        variant: "primary",
-      },
-      style: {
-        backgroundColor: black,
-        color: white,
-        fill: white,
-        border: "none",
-        ":hover": {
-          backgroundColor: disabled,
-        },
-        ":active": {
-          backgroundColor: activeLight,
-        },
-        ":disabled": {
-          backgroundColor: background,
-          color: disabled,
-          fill: disabled,
-        },
-      },
-    },
-    {
-      variants: {
-        theme: "light",
-        variant: "primary",
-      },
-      style: {
-        backgroundColor: white,
-        color: black,
-        fill: black,
-        border: "none",
-        ":hover": {
-          backgroundColor: background,
-        },
-        ":active": {
-          backgroundColor: activeDark,
-        },
-        ":disabled": {
-          backgroundColor: background,
-          color: disabled,
-          fill: disabled,
-        },
-      },
-    },
-    {
-      variants: {
-        theme: "dark",
-        variant: "secondary",
-      },
-      style: {
-        backgroundColor: white,
-        color: black,
-        fill: black,
-        border: `1px solid ${black}`,
-        ":hover": {
-          backgroundColor: black,
-          color: white,
-          fill: white,
-        },
-        ":active": {
-          color: white,
-          fill: white,
-          backgroundColor: activeLight,
-        },
-        ":disabled": {
-          color: disabled,
-          fill: disabled,
-          backgroundColor: white,
-          border: `1px solid ${disabled}`,
-        },
-      },
-    },
-    {
-      variants: {
-        theme: "light",
-        variant: "secondary",
-      },
-      style: {
-        backgroundColor: black,
-        color: white,
-        fill: white,
-        border: `1px solid ${white}`,
-        ":hover": {
-          backgroundColor: white,
-          color: black,
-          fill: black,
-        },
-        ":active": {
-          backgroundColor: background,
-          color: black,
-          fill: black,
-        },
-        ":disabled": {
-          color: disabled,
-          fill: disabled,
-          backgroundColor: black,
-          border: `1px solid ${disabled}`,
-        },
-      },
-    },
-    {
-      variants: {
-        theme: "dark",
-        variant: "tertiary",
-      },
-      style: {
-        backgroundColor: "transparent",
-        color: black,
-        fill: black,
-        ":hover": {
-          backgroundColor: black,
-          color: white,
-          fill: white,
-        },
-        ":active": {
-          backgroundColor: activeLight,
-          color: white,
-          fill: white,
-        },
-        ":disabled": {
-          color: disabled,
-          fill: disabled,
-          backgroundColor: "transparent",
-        },
-      },
-    },
-    {
-      variants: {
-        theme: "light",
-        variant: "tertiary",
-      },
-      style: {
-        backgroundColor: "transparent",
-        color: white,
-        fill: white,
-        ":hover": {
-          backgroundColor: white,
-          color: black,
-          fill: black,
-        },
-        ":active": {
-          backgroundColor: background,
-          color: black,
-          fill: black,
-        },
-        ":disabled": {
-          color: disabled,
-          fill: disabled,
-          backgroundColor: "transparent",
-        },
-      },
-    },
-  ],
 });

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,4 +1,4 @@
-import {fireEvent, render, RenderResult} from "@testing-library/react";
+import { fireEvent, render, RenderResult } from "@testing-library/react";
 import { Button } from "./Button.tsx";
 import { expect, describe, vi } from "vitest";
 import { useEffect, useRef } from "react";
@@ -9,8 +9,8 @@ describe("Button component", () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it("renders with a theme", () => {
-    const { container } = render(<Button theme="dark">Click me</Button>);
+  it("renders with a variant", () => {
+    const { container } = render(<Button variant="secondary">Click me</Button>);
     expect(container.firstChild).toMatchSnapshot();
   });
 
@@ -19,26 +19,28 @@ describe("Button component", () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  describe("when it is disabled",()=>{
-    let component:RenderResult
-    const onPress = vi.fn()
-    const buttonTestId = "buttonId"
-    beforeEach(()=>{
-      component = render(<Button disabled data-testid={buttonTestId} onPress={onPress}>Click me</Button>);
-    })
+  describe("when it is disabled", () => {
+    let component: RenderResult;
+    const onPress = vi.fn();
+    const buttonTestId = "buttonId";
+    beforeEach(() => {
+      component = render(
+        <Button disabled data-testid={buttonTestId} onPress={onPress}>
+          Click me
+        </Button>
+      );
+    });
 
     it("renders with a disabled state", () => {
       expect(component.container.firstChild).toMatchSnapshot();
     });
 
     it("no callback is called when pressed", () => {
-      const button = component.getByTestId(buttonTestId)
-      fireEvent.click(button)
-      expect(onPress).not.toBeCalled()
+      const button = component.getByTestId(buttonTestId);
+      fireEvent.click(button);
+      expect(onPress).not.toBeCalled();
     });
-
-  })
-
+  });
 
   it("renders with a loading state", () => {
     const { container } = render(<Button loading>Click me</Button>);
@@ -46,17 +48,17 @@ describe("Button component", () => {
   });
 
   it("passing a ref works as expected", () => {
-    const refHasValue = vi.fn()
-    
+    const refHasValue = vi.fn();
+
     const Wrapper = () => {
-      const ref = useRef(null)
+      const ref = useRef(null);
 
       useEffect(() => {
-        (ref.current !== null) && refHasValue()
-      }, [ref])
+        ref.current !== null && refHasValue();
+      }, [ref]);
 
-      return <Button ref={ref}>Click me</Button>
-    }
+      return <Button ref={ref}>Click me</Button>;
+    };
 
     const { container } = render(<Wrapper />);
     expect(container.firstChild).toMatchSnapshot();

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, {ButtonHTMLAttributes, forwardRef} from "react";
+import React, { ButtonHTMLAttributes, forwardRef } from "react";
 import type { ButtonProps } from "react-aria-components";
 import { Button as ButtonAria } from "react-aria-components";
 import { Body } from "../Typography";
@@ -13,43 +13,46 @@ type Props = {
   iconLayout?: "sx" | "dx";
   loading?: boolean;
   size?: "small" | "medium" | "large";
-  theme?: "light" | "dark";
   type?: ButtonHTMLAttributes<object>["type"];
   variant?: "primary" | "secondary" | "tertiary";
-} & Omit<ButtonProps, "className"|"isDisabled">;
+} & Omit<ButtonProps, "className" | "isDisabled">;
 
-export const Button = forwardRef<HTMLButtonElement, Props>(({
-  children,
-  disabled = false,
-  loading = false,
-  variant = "primary",
-  theme = "dark",
-  icon,
-  iconLayout = "sx",
-  size = "medium",
-  ...props
-}, ref) => {
-  return (
-    <ButtonAria
-      {...props}
-      ref={ref}
-      isDisabled={disabled}
-      className={ButtonContainer({ iconLayout, size, theme, variant })}
-    >
-      {loading && <Spinner size={size} theme={theme} />}
-      {!loading && icon ? icon : null}
-      {!loading && (size === "small" || size === "medium") ? (
-        <Body size="m" strong={true} noMargin={true}>
-          {children}
-        </Body>
-      ) : null}
-      {!loading && size === "large" ? (
-        <Body size="l" strong={true} noMargin={true}>
-          {children}
-        </Body>
-      ) : null}
-    </ButtonAria>
-  );
-});
+export const Button = forwardRef<HTMLButtonElement, Props>(
+  (
+    {
+      children,
+      disabled = false,
+      loading = false,
+      variant = "primary",
+      icon,
+      iconLayout = "sx",
+      size = "medium",
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <ButtonAria
+        {...props}
+        ref={ref}
+        isDisabled={disabled}
+        className={ButtonContainer({ iconLayout, size, variant })}
+      >
+        {loading && <Spinner size={size} theme="dark" />}
+        {!loading && icon ? icon : null}
+        {!loading && (size === "small" || size === "medium") ? (
+          <Body size="m" strong={true} noMargin={true}>
+            {children}
+          </Body>
+        ) : null}
+        {!loading && size === "large" ? (
+          <Body size="l" strong={true} noMargin={true}>
+            {children}
+          </Body>
+        ) : null}
+      </ButtonAria>
+    );
+  }
+);
 
-Button.displayName = "Button"
+Button.displayName = "Button";

--- a/src/stories/Components.Button.stories.tsx
+++ b/src/stories/Components.Button.stories.tsx
@@ -43,11 +43,6 @@ const meta: Meta<typeof Button> = {
       description: "Choose the size",
       options: ["small", "medium", "large"],
     },
-    theme: {
-      control: "radio",
-      description: "Choose the theme",
-      options: ["light", "dark"],
-    },
     type: {
       control: "select",
       description: "the standard HTML button types",
@@ -61,7 +56,6 @@ const meta: Meta<typeof Button> = {
     iconLayout: "sx",
     loading: false,
     size: "medium",
-    theme: "dark",
     type: "button",
     variant: "primary",
   },
@@ -94,7 +88,6 @@ export const _Button: Story = {
         data-testid={args["data-testid"]}
         disabled={args.disabled}
         loading={args.loading}
-        theme={args.theme}
         icon={Icons[args.icon as keyof typeof Icons]}
         iconLayout={args.iconLayout}
         size={args.size}

--- a/src/utils/themes/ucscTheme.css.ts
+++ b/src/utils/themes/ucscTheme.css.ts
@@ -1,78 +1,19 @@
 import { createTheme } from "@vanilla-extract/css";
 import { defaultThemeValues, themeContract } from "./themeContract.css";
 
-const ucscPalette = {
-  W: "#FFFFFF",
-  k1: "#F5F5F5",
-  k2: "#E5E5E5",
-  k7: "#666666",
-  k10: "#262626",
-  t1: "#006375",
-  t2: "#007A91",
-  t3: "#BFEBF3",
-  t4: "#E7F8FB",
-};
+// const ucscPalette = {
+//   W: "#FFFFFF",
+//   k1: "#F5F5F5",
+//   k2: "#E5E5E5",
+//   k7: "#666666",
+//   k10: "#262626",
+//   t1: "#006375",
+//   t2: "#007A91",
+//   t3: "#BFEBF3",
+//   t4: "#E7F8FB",
+// };
 
 const ucscThemeValues = {
   ...defaultThemeValues,
-  colors: {
-    ...defaultThemeValues.colors,
-    buttons: {
-      dark: {
-        background: {
-          "active, pressed": ucscPalette.t2,
-          default: ucscPalette.t2,
-          disabled: ucscPalette.t2,
-          hover: ucscPalette.t2,
-          "hover-tertiary": ucscPalette.t2,
-          inverted: "#737372ff",
-          "round-default": "#ffffffff",
-          "round-hover": "#f5f5f5ff",
-        },
-        border: {
-          "active, pressed": "#525251ff",
-          default: "#ffffffff",
-          disabled: "#e8e8e8ff",
-          hover: "#e8e8e8ff",
-          "hover-tertiary": "#e8e8e8ff",
-          "round-default": "#ffffffff",
-          "round-hover": "#f5f5f5ff",
-        },
-        text: {
-          disabled: "#737372ff",
-          inverted: "#1d1d1bff",
-          primary: "#ffffffff",
-          round: "#1d1d1bff",
-        },
-      },
-      light: {
-        background: {
-          "active, pressed": "#525251ff",
-          default: "#1d1d1bff",
-          disabled: "#e8e8e8ff",
-          hover: "#737372ff",
-          "hover-tertiary": "#e8e8e8ff",
-          inverted: "#ffffffff",
-          "round-default": "#e8e8e8ff",
-          "round-hover": "#d4d4d3ff",
-        },
-        border: {
-          "active, pressed": "#525251ff",
-          default: "#1d1d1bff",
-          disabled: "#e8e8e8ff",
-          hover: "#737372ff",
-          "hover-tertiary": "#e8e8e8ff",
-          "round-default": "#ffffffff",
-          "round-hover": "#f5f5f5ff",
-        },
-        text: {
-          disabled: "#737372ff",
-          inverted: "#ffffffff",
-          primary: "#1d1d1bff",
-          round: "#1d1d1bff",
-        },
-      },
-    },
-  },
 };
 export const UcscHabitatTheme = createTheme(themeContract, ucscThemeValues);

--- a/src/utils/tokens.json
+++ b/src/utils/tokens.json
@@ -142,59 +142,25 @@
     }
   },
   "buttons": {
-    "light": {
-      "text": {
-        "primary": "#1d1d1bff",
-        "inverted": "#ffffffff",
-        "disabled": "#737372ff",
-        "round": "#1d1d1bff"
-      },
-      "background": {
-        "default": "#1d1d1bff",
-        "inverted": "#ffffffff",
-        "hover": "#737372ff",
-        "hover-tertiary": "#e8e8e8ff",
-        "active, pressed": "#525251ff",
-        "disabled": "#e8e8e8ff",
-        "round-default": "#e8e8e8ff",
-        "round-hover": "#d4d4d3ff"
-      },
-      "border": {
-        "default": "#1d1d1bff",
-        "hover": "#737372ff",
-        "active, pressed": "#525251ff",
-        "disabled": "#e8e8e8ff",
-        "hover-tertiary": "#e8e8e8ff",
-        "round-default": "#ffffffff",
-        "round-hover": "#f5f5f5ff"
-      }
+    "background": {
+      "default": "#1d1d1bff",
+      "inverted": "#ffffffff",
+      "hover": "#737372ff",
+      "hover-tertiary": "#E8E8E8FF",
+      "active, pressed": "#525251FF",
+      "disabled": "#E8E8E8FF"
     },
-    "dark": {
-      "text": {
-        "primary": "#ffffffff",
-        "inverted": "#1d1d1bff",
-        "disabled": "#737372ff",
-        "round": "#1d1d1bff"
-      },
-      "background": {
-        "default": "#ffffffff",
-        "inverted": "#737372ff",
-        "hover": "#e8e8e8ff",
-        "hover-tertiary": "#e8e8e8ff",
-        "active, pressed": "#d4d4d3ff",
-        "disabled": "#e8e8e8ff",
-        "round-default": "#ffffffff",
-        "round-hover": "#f5f5f5ff"
-      },
-      "border": {
-        "default": "#ffffffff",
-        "hover": "#e8e8e8ff",
-        "active, pressed": "#525251ff",
-        "disabled": "#e8e8e8ff",
-        "hover-tertiary": "#e8e8e8ff",
-        "round-default": "#ffffffff",
-        "round-hover": "#f5f5f5ff"
-      }
+    "text": {
+      "primary": "#1d1d1bff",
+      "inverted": "#ffffffff",
+      "disabled": "#737372ff"
+    },
+    "border": {
+      "default": "#1d1d1bff",
+      "hover": "#737372ff",
+      "hover-tertiary": "#E8E8E8FF",
+      "active, pressed": "#525251FF",
+      "disabled": "#E8E8E8FF"
     }
   }
 }


### PR DESCRIPTION
## Figma reference/Github issue

[Figma semantic button tokens](https://www.figma.com/design/0vYcLbHGHFIJ44hFI45WQJ/%F0%9F%9A%80-Habitat?node-id=17237-39834&t=SzHbgkTcFkNCFXV3-0) 
[Figma Button](https://www.figma.com/design/0vYcLbHGHFIJ44hFI45WQJ/%F0%9F%9A%80-Habitat?node-id=17296-6836&t=5zjs1uPTsk7stbAT-0) 


## What

Aligns the habitat button implementation to match the most recent figma semantic tokens association.

**Critical Note:** Unfortunately the process of automatically generatic the theme contract tokens from the figma export failed so the file `src/utils/tokens.json` was modified manually.

## [OPTIONAL] Why

Misalignment between the Habitat implementation of the Button and the Figma button reference.
